### PR TITLE
Security hardening, unit tests, Docker support and UI rework

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# VCS / editor
+.git
+.gitignore
+.vscode
+.idea
+
+# Local runtime state (must never be baked into the image)
+.env
+data.db
+data.db-*
+uploads/
+logs/
+temp_admin_credentials.txt
+
+# Build artifacts
+cloudboxio
+cloudboxio.exe
+/out
+*.test
+
+# Docs / misc
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ uploads
 data.db
 logs
 build
+temp_admin_credentials.txt
+
+# Binary built without an extension (go build -o cloudboxio .)
+/cloudboxio
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+
+# ============================ Build stage ============================
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /src
+
+# Download dependencies first so this layer is cached unless go.mod/go.sum change.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Build the binary.
+COPY . .
+# modernc.org/sqlite is a pure-Go driver, so we build a fully static binary
+# with CGO disabled. -trimpath + -ldflags "-s -w" keep the binary small.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/cloudboxio .
+
+# =========================== Runtime stage ==========================
+# Small image that still ships a shell for easy debugging. For a stricter
+# footprint you can swap this for: gcr.io/distroless/static-debian12:nonroot
+FROM alpine:3.20
+
+# Run as an unprivileged user and keep all state in a writable data dir.
+RUN addgroup -S app && adduser -S app -G app \
+ && mkdir -p /data && chown app:app /data \
+ && apk add --no-cache ca-certificates
+
+COPY --from=builder /out/cloudboxio /usr/local/bin/cloudboxio
+
+USER app
+WORKDIR /data
+
+# On first run the app generates .env, data.db, logs/ and uploads/ in the
+# working directory. Mount a volume here so that state survives restarts.
+VOLUME ["/data"]
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/cloudboxio"]

--- a/README.md
+++ b/README.md
@@ -34,15 +34,19 @@ CloudBoxIO allows users to securely upload, share, and manage files with JWT-bas
 > Switch between the light, dark and glass themes from the header, the choice is remembered in the browser.
 
 <p align="center">
-  <img src="https://i.postimg.cc/ZRLWYKMC/index.png" alt="Landing page" width="600">
+  <img src="https://i.ibb.co/20D510Fk/image.png">
 </p>
 
 <p align="center">
-  <img src="https://i.postimg.cc/VNnSTF99/dashboard.png" alt="Dashboard page" width="600">
+  <img src="https://i.ibb.co/JRpwL71D/image.png">
+</p> 
+
+<p align="center">
+  <img src="https://i.ibb.co/1Y6CDPRC/image.png">
 </p>
 
 <p align="center">
-  <img src="https://i.postimg.cc/HxmJC73q/mobile-view.png" alt="Mobile view" width="250">
+  <img src="https://i.ibb.co/JRShXCBD/image.png">
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,19 +34,7 @@ CloudBoxIO allows users to securely upload, share, and manage files with JWT-bas
 > Switch between the light, dark and glass themes from the header, the choice is remembered in the browser.
 
 <p align="center">
-  <img src="https://i.ibb.co/20D510Fk/image.png">
-</p>
-
-<p align="center">
-  <img src="https://i.ibb.co/JRpwL71D/image.png">
-</p> 
-
-<p align="center">
   <img src="https://i.ibb.co/1Y6CDPRC/image.png">
-</p>
-
-<p align="center">
-  <img src="https://i.ibb.co/JRShXCBD/image.png">
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ CloudBoxIO allows users to securely upload, share, and manage files with JWT-bas
 - 🎛️ Admin-only user management
 - 🗂️ Upload multiple files
 - 🛑 Graceful shutdown
-- 📱 Minimal Web UI
+- 📱 Minimal Web UI with three built-in themes (light, dark, glass)
 - 🔍 Search through uploaded or shared files by filename using query parameters
 - 🚧 Rate Limiting
+- 🔒 Optional TLS (HTTPS) support
+- 🐳 Docker support
 - 🧪 Unit testing
 
 ---
@@ -29,6 +31,7 @@ CloudBoxIO allows users to securely upload, share, and manage files with JWT-bas
 ## </> UI
 
 > CloudBoxIO includes a clean, responsive UI for file management out of the box.
+> Switch between the light, dark and glass themes from the header, the choice is remembered in the browser.
 
 <p align="center">
   <img src="https://i.postimg.cc/ZRLWYKMC/index.png" alt="Landing page" width="600">
@@ -56,7 +59,21 @@ go build .
 ./cloudboxio
 ```
 
-> 💡 A `.env` file will be generated automatically on first run. You can edit it to change port, file directories, upload size, rate limiting, and more.
+> 💡 A `.env` file will be generated automatically on first run. You can edit it to change port, file directories, upload size, token lifetime, TLS certificates, rate limiting, and more.
+
+### 🐳 Docker
+
+```bash
+docker compose up --build
+```
+
+> 💡 State (`data.db`, `uploads/`, `logs/`, `.env`) is kept in the `/data` volume. The one-time admin password is written to `/data/temp_admin_credentials.txt`.
+
+### 🧪 Tests
+
+```bash
+go test ./...
+```
 
 ---
 
@@ -82,7 +99,6 @@ This project is licensed under the [MIT License](https://github.com/AumSahayata/
 - Ask questions or share ideas in [Discussions](https://github.com/AumSahayata/cloudboxio/discussions)  
 - Report bugs via [Issues](https://github.com/AumSahayata/cloudboxio/issues)  
 - Suggestions welcome! You can contribute:
-  - 🔄 Docker support  
   - 💻 Frontend improvements  
   - 🛠️ CI pipelines or GitHub Actions  
   - 🧪 Integration testing  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  cloudboxio:
+    build: .
+    image: cloudboxio:latest
+    container_name: cloudboxio
+    ports:
+      - "3000:3000"
+    volumes:
+      # Persist app state (data.db, uploads, logs, .env) on the host.
+      - cloudboxio_data:/data
+    restart: unless-stopped
+    # Optional overrides (the app also writes these into /data/.env on first run):
+    # environment:
+    #   PORT: "3000"
+    #   JWT_EXPIRY_HOURS: "24"
+    #   MAX_UPLOAD_SIZE_MB: "100"
+
+volumes:
+  cloudboxio_data:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,186 +1,170 @@
-// API Configuration
+// ============================================================ CloudBoxIO UI
 const API_URL = '/api';
 
-// Helper function to truncate text
-function truncateText(text, maxLength = 35) {
-    if (!text) return '';
-    if (text.length <= maxLength) return text;
-    return text.substring(0, maxLength) + '...';
-}
+/* ----------------------------------------------------------------- themes */
+const THEME_KEY = 'cbio-theme';
+const THEMES = ['paper', 'carbon', 'aurora'];
 
-// Helper function to format file size
-function formatFileSize(bytes) {
-    if (!bytes) return '0 Bytes';
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-}
-
-// Helper function to format date
-function formatDate(timestamp) {
-    if (!timestamp) return '';
-    return new Date(timestamp).toLocaleString();
-}
-
-// Display files in the list
-function displayFiles(files, container, sectionTitle) {
-    if (!container) return;
-
-    container.innerHTML = '';
-
-    if (!Array.isArray(files) || files.length === 0) {
-        const noFilesElement = document.createElement('div');
-        noFilesElement.className = 'list-group-item text-center text-muted';
-        noFilesElement.textContent = 'No files found';
-        container.appendChild(noFilesElement);
-        return;
-    }
-
-    files.forEach(file => {
-        const fileItem = createFileListItem(file);
-        container.appendChild(fileItem);
+function applyTheme(theme) {
+    if (!THEMES.includes(theme)) theme = 'paper';
+    document.documentElement.setAttribute('data-theme', theme);
+    try { localStorage.setItem(THEME_KEY, theme); } catch (_) {}
+    document.querySelectorAll('.ts-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.themeValue === theme);
     });
 }
 
-// Create file list item
-function createFileListItem(file) {
-    const item = document.createElement('div');
-    item.className = 'list-group-item';
-
-    const isPublic = file.is_public;
-    const fileId = file.id || file.file_id || file.fileId || file.filename;
-    const filename = file.filename;
-
-    if (!fileId) {
-        console.error('File ID not found:', file);
-        return item;
-    }
-
-    item.innerHTML = `
-        <div class="d-flex">
-            <div class="file-name">
-                <strong data-bs-toggle="tooltip" data-bs-placement="top" title="${filename}">
-                    <span class="desktop-filename">${filename}</span>
-                    <span class="mobile-filename">${truncateText(filename)}</span>
-                </strong>
-                <small class="text-muted d-block">
-                    ${formatFileSize(file.size)} • ${formatDate(file.uploaded_at)}
-                    ${isPublic ? ' • Public' : ''}
-                    ${file.uploaded_by ? ` • Uploaded by: ${file.uploaded_by}` : ''}
-                </small>
-            </div>
-            <div class="btn-group">
-                <button class="btn btn-sm btn-primary" onclick="downloadFile('${fileId}', '${filename.replace(/'/g, "\\'")}')">
-                    <i class="bi bi-download"></i> Download
-                </button>
-                <button class="btn btn-sm btn-danger" onclick="deleteFile('${fileId}')">
-                    <i class="bi bi-trash"></i> Delete
-                </button>
-            </div>
-            <div class="mobile-dropdown">
-                <button class="btn btn-outline-secondary btn-sm w-100 dropdown-toggle" type="button" data-bs-toggle="dropdown">
-                    Actions
-                </button>
-                <ul class="dropdown-menu">
-                    <li><a class="dropdown-item" href="#" onclick="downloadFile('${fileId}', '${filename.replace(/'/g, "\\'")}')">
-                        <i class="bi bi-download"></i> Download
-                    </a></li>
-                    <li><a class="dropdown-item text-danger" href="#" onclick="deleteFile('${fileId}')">
-                        <i class="bi bi-trash"></i> Delete
-                    </a></li>
-                </ul>
-            </div>
-        </div>
-    `;
-
-    // Initialize tooltips for this item
-    const tooltipTriggerList = item.querySelectorAll('[data-bs-toggle="tooltip"]');
-    [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
-
-    return item;
+function initTheme() {
+    let saved = 'paper';
+    try { saved = localStorage.getItem(THEME_KEY) || 'paper'; } catch (_) {}
+    applyTheme(saved);
+    document.querySelectorAll('.ts-btn').forEach(btn => {
+        btn.addEventListener('click', () => applyTheme(btn.dataset.themeValue));
+    });
 }
 
-// Loading overlay functions
-function showLoading(message = 'Loading...') {
-    let overlay = document.getElementById('loadingOverlay');
-    if (!overlay) {
-        overlay = document.createElement('div');
-        overlay.id = 'loadingOverlay';
-        overlay.className = 'loading-overlay';
-        overlay.innerHTML = `
-            <div class="loading-content">
-                <div class="spinner-border text-primary" role="status">
-                    <span class="visually-hidden">Loading...</span>
-                </div>
-                <div class="loading-message mt-2">${message}</div>
-            </div>
-        `;
-        document.body.appendChild(overlay);
-    } else {
-        const messageElement = overlay.querySelector('.loading-message');
-        if (messageElement) {
-            messageElement.textContent = message;
-        }
-    }
-    overlay.style.display = 'flex';
+/* --------------------------------------------------------------- helpers */
+function formatFileSize(bytes) {
+    if (!bytes || bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
 
+function formatDate(timestamp) {
+    if (!timestamp) return '';
+    const d = new Date(timestamp);
+    if (isNaN(d)) return '';
+    return d.toLocaleString(undefined, {
+        year: 'numeric', month: 'short', day: '2-digit',
+        hour: '2-digit', minute: '2-digit'
+    });
+}
+
+function iconForFilename(name) {
+    const ext = (name.split('.').pop() || '').toLowerCase();
+    const map = {
+        pdf: 'bi-filetype-pdf', doc: 'bi-filetype-doc', docx: 'bi-filetype-docx',
+        xls: 'bi-filetype-xlsx', xlsx: 'bi-filetype-xlsx', csv: 'bi-filetype-csv',
+        ppt: 'bi-filetype-pptx', pptx: 'bi-filetype-pptx', txt: 'bi-filetype-txt',
+        md: 'bi-filetype-md', json: 'bi-filetype-json', xml: 'bi-filetype-xml',
+        html: 'bi-filetype-html', css: 'bi-filetype-css', js: 'bi-filetype-js',
+        py: 'bi-filetype-py', java: 'bi-filetype-java', sh: 'bi-filetype-sh',
+        png: 'bi-filetype-png', jpg: 'bi-filetype-jpg', jpeg: 'bi-filetype-jpg',
+        gif: 'bi-filetype-gif', svg: 'bi-filetype-svg', webp: 'bi-file-image',
+        mp3: 'bi-filetype-mp3', wav: 'bi-filetype-wav', mp4: 'bi-filetype-mp4',
+        mov: 'bi-filetype-mov', zip: 'bi-file-zip', tar: 'bi-file-zip',
+        gz: 'bi-file-zip', rar: 'bi-file-zip', '7z': 'bi-file-zip'
+    };
+    return map[ext] || 'bi-file-earmark';
+}
+
+/* ------------------------------------------------------ loading overlay */
+function showLoading(message = 'Loading…') {
+    const overlay = document.getElementById('loadingOverlay');
+    const msg = document.getElementById('loadingMsg');
+    if (msg) msg.textContent = message;
+    if (overlay) overlay.classList.add('show');
+}
 function hideLoading() {
     const overlay = document.getElementById('loadingOverlay');
-    if (overlay) {
-        overlay.style.display = 'none';
-    }
+    if (overlay) overlay.classList.remove('show');
 }
 
-// Add loading overlay styles
-const style = document.createElement('style');
-style.textContent = `
-    .loading-overlay {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.5);
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 9999;
-    }
-    .loading-content {
-        background-color: white;
-        padding: 2rem;
-        border-radius: 8px;
-        text-align: center;
-        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    }
-    .loading-message {
-        color: #666;
-        margin-top: 1rem;
-    }
+/* --------------------------------------------------------- safe rendering */
+// Build a file row entirely with DOM APIs + textContent. User-controlled
+// values (filename, uploaded_by) are NEVER interpolated into HTML, which
+// removes the stored-XSS vector the old innerHTML template had.
+function createFileRow(file) {
+    const fileId = file.file_id || file.id || file.fileId;
+    const filename = file.filename || '';
 
-    /* Filename display styles */
-    .desktop-filename {
-        display: inline;
-    }
-    .mobile-filename {
-        display: none;
-    }
+    const row = document.createElement('div');
+    row.className = 'file-row';
 
-    @media (max-width: 768px) {
-        .desktop-filename {
-            display: none;
-        }
-        .mobile-filename {
-            display: inline;
-        }
-    }
-`;
-document.head.appendChild(style);
+    const icon = document.createElement('i');
+    icon.className = 'bi ' + iconForFilename(filename) + ' file-icon';
+    row.appendChild(icon);
 
-// Helper to get token or redirect to login if missing
+    const main = document.createElement('div');
+    main.className = 'file-main';
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'file-name';
+    nameEl.textContent = filename;
+    nameEl.title = filename;
+    main.appendChild(nameEl);
+
+    const meta = document.createElement('div');
+    meta.className = 'file-meta';
+
+    const sizeEl = document.createElement('span');
+    sizeEl.textContent = formatFileSize(file.size);
+    meta.appendChild(sizeEl);
+
+    const dateStr = formatDate(file.uploaded_at);
+    if (dateStr) {
+        meta.appendChild(makeSep());
+        const dateEl = document.createElement('span');
+        dateEl.textContent = dateStr;
+        meta.appendChild(dateEl);
+    }
+    if (file.uploaded_by && file.uploaded_by !== 'Me') {
+        meta.appendChild(makeSep());
+        const byEl = document.createElement('span');
+        byEl.className = 'uploader';
+        byEl.textContent = '@' + file.uploaded_by;
+        meta.appendChild(byEl);
+    }
+    main.appendChild(meta);
+    row.appendChild(main);
+
+    const actions = document.createElement('div');
+    actions.className = 'file-actions';
+
+    const dlBtn = document.createElement('button');
+    dlBtn.className = 'icon-btn';
+    dlBtn.title = 'Download';
+    dlBtn.innerHTML = '<i class="bi bi-download"></i>';
+    dlBtn.addEventListener('click', () => downloadFile(fileId, filename));
+    actions.appendChild(dlBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'icon-btn danger';
+    delBtn.title = 'Delete';
+    delBtn.innerHTML = '<i class="bi bi-trash3"></i>';
+    delBtn.addEventListener('click', () => deleteFile(fileId));
+    actions.appendChild(delBtn);
+
+    row.appendChild(actions);
+    return row;
+}
+
+function makeSep() {
+    const s = document.createElement('span');
+    s.className = 'sep';
+    s.textContent = '·';
+    return s;
+}
+
+function displayFiles(files, container, countEl) {
+    if (!container) return;
+    container.textContent = '';
+    const list = Array.isArray(files) ? files : [];
+    if (countEl) countEl.textContent = String(list.length);
+
+    if (list.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-row';
+        empty.textContent = 'No files yet';
+        container.appendChild(empty);
+        return;
+    }
+    list.forEach(f => container.appendChild(createFileRow(f)));
+}
+
+/* ------------------------------------------------------------ auth token */
 function getAuthTokenOrRedirect() {
     const token = localStorage.getItem('token');
     if (!token) {
@@ -191,109 +175,47 @@ function getAuthTokenOrRedirect() {
     return token;
 }
 
-// Global loadFiles function
-async function loadFiles() {
-    showLoading('Loading files...');
-    try {
-        // Load my files
-        const myFilesResponse = await fetch(`${API_URL}/files`, {
-            headers: {
-                'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-            },
-        });
-        const myFilesData = await myFilesResponse.json();
-        if (!myFilesResponse.ok) {
-            throw new Error(myFilesData.error || 'Failed to fetch my files');
-        }
-        const myFilesList = document.getElementById('myFilesList');
-        if (myFilesList) {
-            displayFiles(myFilesData, myFilesList, 'My Files');
-        }
+function authHeaders(extra) {
+    return Object.assign({ 'Authorization': `Bearer ${getAuthTokenOrRedirect()}` }, extra || {});
+}
 
-        // Load shared files
-        const sharedFilesResponse = await fetch(`${API_URL}/files?shared=true`, {
-            headers: {
-                'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-            },
-        });
-        const sharedFilesData = await sharedFilesResponse.json();
-        if (!sharedFilesResponse.ok) {
-            throw new Error(sharedFilesData.error || 'Failed to fetch shared files');
-        }
-        const sharedFilesList = document.getElementById('sharedFilesList');
-        if (sharedFilesList) {
-            displayFiles(sharedFilesData, sharedFilesList, 'Public Files');
-        }
+/* --------------------------------------------------------------- files */
+async function loadFiles() {
+    showLoading('Loading files…');
+    try {
+        const myResp = await fetch(`${API_URL}/files`, { headers: authHeaders() });
+        handleApiResponse(myResp);
+        const myData = await myResp.json();
+        if (!myResp.ok) throw new Error(myData.error || 'Failed to fetch files');
+        displayFiles(myData, document.getElementById('myFilesList'),
+                     document.getElementById('myFilesCount'));
+
+        const shResp = await fetch(`${API_URL}/files?shared=true`, { headers: authHeaders() });
+        handleApiResponse(shResp);
+        const shData = await shResp.json();
+        if (!shResp.ok) throw new Error(shData.error || 'Failed to fetch public files');
+        displayFiles(shData, document.getElementById('sharedFilesList'),
+                     document.getElementById('sharedFilesCount'));
     } catch (error) {
         console.error('Error loading files:', error);
-        alert(error.message || 'Error loading files');
     } finally {
         hideLoading();
     }
 }
 
-// Global logout function
-function logout() {
-    // Clear token
-    localStorage.removeItem('token');
-
-    // Clear the file lists
-    const myFilesList = document.getElementById('myFilesList');
-    const sharedFilesList = document.getElementById('sharedFilesList');
-    if (myFilesList) myFilesList.innerHTML = '';
-    if (sharedFilesList) sharedFilesList.innerHTML = '';
-
-    // Reset all forms
-    const forms = document.querySelectorAll('form');
-    forms.forEach(form => {
-        form.reset();
-        // Clear any validation states or error messages
-        const inputs = form.querySelectorAll('input');
-        inputs.forEach(input => {
-            input.classList.remove('is-invalid', 'is-valid');
-            // Clear any custom validation messages
-            const feedback = input.nextElementSibling;
-            if (feedback && feedback.classList.contains('invalid-feedback')) {
-                feedback.textContent = '';
-            }
-        });
-    });
-
-    // Close any open modals
-    const modals = document.querySelectorAll('.modal');
-    modals.forEach(modal => {
-        const modalInstance = bootstrap.Modal.getInstance(modal);
-        if (modalInstance) {
-            modalInstance.hide();
-        }
-    });
-
-    // Clear any error messages or alerts
-    const alerts = document.querySelectorAll('.alert');
-    alerts.forEach(alert => alert.remove());
-
-    // Update UI using the new function
-    showUnauthenticatedUI();
-    showLoginModal();
-}
-
-// Delete file
 async function deleteFile(fileId) {
-    if (!confirm('Are you sure you want to delete this file?')) return;
-
-    showLoading('Deleting file...');
+    if (!fileId) return;
+    if (!confirm('Delete this file?')) return;
+    showLoading('Deleting…');
     try {
-        const response = await fetch(`${API_URL}/file/${fileId}`, {
-            method: 'DELETE',
-            headers: {
-                'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-            },
+        const response = await fetch(`${API_URL}/file/${encodeURIComponent(fileId)}`, {
+            method: 'DELETE', headers: authHeaders()
         });
         handleApiResponse(response);
         if (response.ok) {
-            await loadFiles(); // Reload the file list after successful deletion
+            await loadFiles();
         } else {
-            const data = await response.json();
+            const data = await response.json().catch(() => ({}));
             alert(data.error || 'Delete failed');
         }
     } catch (error) {
@@ -303,41 +225,26 @@ async function deleteFile(fileId) {
     }
 }
 
-// Download file
 async function downloadFile(fileId, filename) {
-    if (!fileId) {
-        alert('Invalid file ID');
-        return;
-    }
-
-    showLoading('Preparing download...');
+    if (!fileId) { alert('Invalid file ID'); return; }
+    showLoading('Preparing download…');
     try {
-        const response = await fetch(`${API_URL}/file/${fileId}`, {
-            headers: {
-                'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-            },
+        const response = await fetch(`${API_URL}/file/${encodeURIComponent(fileId)}`, {
+            headers: authHeaders()
         });
         handleApiResponse(response);
         if (!response.ok) {
-            const data = await response.json();
+            const data = await response.json().catch(() => ({}));
             throw new Error(data.error || 'Download failed');
         }
-
-        // Get the blob from the response
         const blob = await response.blob();
-
-        // Create a temporary URL for the blob
         const url = window.URL.createObjectURL(blob);
-
-        // Create a temporary link element
         const link = document.createElement('a');
         link.href = url;
-        link.download = filename; // Use the passed filename
+        link.download = filename || 'download';
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
-
-        // Clean up the URL
         window.URL.revokeObjectURL(url);
     } catch (error) {
         alert(`Error during download: ${error.message || error}`);
@@ -346,124 +253,31 @@ async function downloadFile(fileId, filename) {
     }
 }
 
-// Initialize password visibility toggles
-function togglePasswordVisibility(inputId, buttonId) {
-    const input = document.getElementById(inputId);
-    const button = document.getElementById(buttonId);
-    if (input && button) {
-        button.addEventListener('click', () => {
-            const type = input.type === 'password' ? 'text' : 'password';
-            input.type = type;
-            button.innerHTML = `<i class="bi bi-eye${type === 'password' ? '' : '-slash'}"></i>`;
-        });
-    }
+/* -------------------------------------------------------------- session */
+function logout() {
+    localStorage.removeItem('token');
+
+    const myFiles = document.getElementById('myFilesList');
+    const shFiles = document.getElementById('sharedFilesList');
+    if (myFiles) myFiles.textContent = '';
+    if (shFiles) shFiles.textContent = '';
+
+    document.querySelectorAll('form').forEach(form => {
+        form.reset();
+        form.querySelectorAll('input').forEach(i => i.classList.remove('is-invalid', 'is-valid'));
+    });
+
+    document.querySelectorAll('.modal').forEach(modal => {
+        const inst = bootstrap.Modal.getInstance(modal);
+        if (inst) inst.hide();
+    });
+
+    showUnauthenticatedUI();
+    showLoginModal();
 }
 
-// Check authentication status
-function checkAuth() {
-    const token = localStorage.getItem('token');
-    if (token) {
-        showAuthenticatedUI();
-    } else {
-        showUnauthenticatedUI();
-    }
-}
-
-// Fetch and display user details
-async function fetchUserDetails() {
-    try {
-        const response = await fetch(`${API_URL}/user-info`, {
-            headers: {
-                'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-            },
-        });
-        handleApiResponse(response);
-        if (response.status === 404) {
-            // User not found, treat as unauthenticated
-            localStorage.removeItem('token');
-            showUnauthenticatedUI();
-            showLoginModal();
-            throw new Error('User not found. Please log in again.');
-        }
-        if (!response.ok) {
-            throw new Error('Failed to fetch user details');
-        }
-        const userData = await response.json();
-        displayUserDetails(userData);
-    } catch (error) {
-        console.error('Error fetching user details:', error);
-        alert('Failed to load user details');
-    }
-}
-
-// Display user details in the UI
-function displayUserDetails(userData) {
-    if (!userData) return;
-    // Update navigation username
-    const navUsername = document.getElementById('navUsername');
-    if (navUsername) {
-        // Add admin badge if user is admin
-        navUsername.textContent = userData.username;
-        if (userData.is_admin) {
-            navUsername.innerHTML += ' <span class="badge bg-warning">Admin</span>';
-            // Show admin-only options
-            document.getElementById('createUserNavItem').style.display = 'block';
-            document.getElementById('createUserDivider').style.display = 'block';
-            // Show users panel nav item
-            const showUsersPanelNavItem = document.getElementById('showUsersPanelNavItem');
-            if (showUsersPanelNavItem) showUsersPanelNavItem.style.display = 'block';
-        } else {
-            // Hide admin-only options
-            document.getElementById('createUserNavItem').style.display = 'none';
-            document.getElementById('createUserDivider').style.display = 'none';
-            // Hide users panel nav item
-            const showUsersPanelNavItem = document.getElementById('showUsersPanelNavItem');
-            if (showUsersPanelNavItem) showUsersPanelNavItem.style.display = 'none';
-        }
-    }
-}
-
-// Show authenticated UI
-function showAuthenticatedUI() {
-    // Show user profile
-    const userProfileNav = document.getElementById('userProfileNav');
-    if (userProfileNav) userProfileNav.classList.remove('d-none');
-
-    // Show main content
-    document.getElementById('authSection').style.display = 'none';
-    document.getElementById('mainSection').style.display = 'block';
-
-    // Fetch and display user details
-    fetchUserDetails();
-
-    // Load files
-    loadFiles();
-}
-
-// Show unauthenticated UI
-function showUnauthenticatedUI() {
-    // Hide user profile
-    const userProfileNav = document.getElementById('userProfileNav');
-    if (userProfileNav) userProfileNav.classList.add('d-none');
-
-    // Show auth content
-    document.getElementById('authSection').style.display = 'block';
-    document.getElementById('mainSection').style.display = 'none';
-}
-
-// Helper to show the login modal
-function showLoginModal() {
-    const loginModalElement = document.getElementById('loginModal');
-    if (loginModalElement) {
-        const loginModal = new bootstrap.Modal(loginModalElement);
-        loginModal.show();
-    }
-}
-
-// Update handleApiResponse to show login modal on 498
 function handleApiResponse(response) {
-    if (response.status === 498) {
-        // Token missing or expired
+    if (response.status === 498 || response.status === 401) {
         localStorage.removeItem('token');
         showUnauthenticatedUI();
         showLoginModal();
@@ -472,44 +286,112 @@ function handleApiResponse(response) {
     return response;
 }
 
-// Helper to render the users panel (admin only)
-function renderUsersPanel(users) {
-    const usersList = document.getElementById('usersList');
-    if (!usersList) return;
-    usersList.innerHTML = '';
-    users.forEach(user => {
-        const userItem = document.createElement('div');
-        userItem.className = 'list-group-item d-flex justify-content-between align-items-center';
-        userItem.innerHTML = `
-            <span><strong>${user.username}</strong> ${user.is_admin ? '<span class="badge bg-warning">Admin</span>' : ''}</span>
-            <button class="btn btn-sm btn-danger delete-user-btn" data-user-id="${user.id}"><i class="bi bi-trash"></i> Delete</button>
-        `;
-        usersList.appendChild(userItem);
-    });
-    // Attach event listeners for delete buttons
-    usersList.querySelectorAll('.delete-user-btn').forEach(btn => {
-        btn.addEventListener('click', function () {
-            const userId = this.getAttribute('data-user-id');
-            deleteUser(userId, this);
-        });
+/* --------------------------------------------------------- user details */
+async function fetchUserDetails() {
+    try {
+        const response = await fetch(`${API_URL}/user-info`, { headers: authHeaders() });
+        if (response.status === 404) {
+            localStorage.removeItem('token');
+            showUnauthenticatedUI();
+            showLoginModal();
+            return;
+        }
+        handleApiResponse(response);
+        if (!response.ok) throw new Error('Failed to fetch user details');
+        displayUserDetails(await response.json());
+    } catch (error) {
+        console.error('Error fetching user details:', error);
+    }
+}
+
+function displayUserDetails(userData) {
+    if (!userData) return;
+    const navUsername = document.getElementById('navUsername');
+    if (navUsername) {
+        navUsername.textContent = userData.username;   // safe: no HTML
+        if (userData.is_admin) {
+            const badge = document.createElement('span');
+            badge.className = 'badge-admin';
+            badge.textContent = 'admin';
+            navUsername.appendChild(badge);
+        }
+    }
+    const adminEls = ['createUserNavItem', 'createUserDivider', 'showUsersPanelNavItem'];
+    adminEls.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.style.display = userData.is_admin ? 'block' : 'none';
     });
 }
 
-// Fetch all users (admin only)
+/* ------------------------------------------------------------- UI state */
+function showAuthenticatedUI() {
+    const nav = document.getElementById('userProfileNav');
+    if (nav) nav.classList.remove('d-none');
+    document.getElementById('authSection').style.display = 'none';
+    document.getElementById('mainSection').style.display = 'block';
+    fetchUserDetails();
+    loadFiles();
+}
+
+function showUnauthenticatedUI() {
+    const nav = document.getElementById('userProfileNav');
+    if (nav) nav.classList.add('d-none');
+    document.getElementById('authSection').style.display = 'block';
+    document.getElementById('mainSection').style.display = 'none';
+    const navUsername = document.getElementById('navUsername');
+    if (navUsername) navUsername.textContent = 'User';
+}
+
+function showLoginModal() {
+    const el = document.getElementById('loginModal');
+    if (el) new bootstrap.Modal(el).show();
+}
+
+function checkAuth() {
+    if (localStorage.getItem('token')) showAuthenticatedUI();
+    else showUnauthenticatedUI();
+}
+
+/* ------------------------------------------------------- users (admin) */
+function renderUsersPanel(users) {
+    const usersList = document.getElementById('usersList');
+    if (!usersList) return;
+    usersList.textContent = '';
+
+    (users || []).forEach(user => {
+        const row = document.createElement('div');
+        row.className = 'user-row';
+
+        const left = document.createElement('span');
+        left.className = 'uname';
+        const strong = document.createElement('strong');
+        strong.textContent = user.username;          // safe
+        left.appendChild(strong);
+        if (user.is_admin) {
+            const badge = document.createElement('span');
+            badge.className = 'badge-admin';
+            badge.textContent = 'admin';
+            left.appendChild(badge);
+        }
+        row.appendChild(left);
+
+        const del = document.createElement('button');
+        del.className = 'btn btn-danger';
+        del.innerHTML = '<i class="bi bi-trash3 me-1"></i>Delete';
+        del.addEventListener('click', () => deleteUser(user.id, del));
+        row.appendChild(del);
+
+        usersList.appendChild(row);
+    });
+}
+
 async function fetchAllUsers() {
     try {
-        showLoading('Loading users...');
-        const response = await fetch(`${API_URL}/users`, {
-            headers: {
-                'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-            },
-        });
+        showLoading('Loading users…');
+        const response = await fetch(`${API_URL}/users`, { headers: authHeaders() });
         handleApiResponse(response);
-        if (!response.ok) {
-            throw new Error('Failed to fetch users');
-        }
-        const users = await response.json();
-        renderUsersPanel(users);
+        if (!response.ok) throw new Error('Failed to fetch users');
+        renderUsersPanel(await response.json());
     } catch (error) {
         console.error('Error fetching users:', error);
         alert(error.message || 'Failed to load users');
@@ -518,25 +400,21 @@ async function fetchAllUsers() {
     }
 }
 
-// Update deleteUser to use id in the API call
 async function deleteUser(userId, btn) {
-    if (!confirm('Are you sure you want to delete this user?')) return;
+    if (!confirm('Delete this user?')) return;
     btn.disabled = true;
     try {
-        showLoading('Deleting user...');
+        showLoading('Deleting user…');
         const response = await fetch(`${API_URL}/users/${encodeURIComponent(userId)}`, {
-            method: 'DELETE',
-            headers: {
-                'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-            },
+            method: 'DELETE', headers: authHeaders()
         });
         handleApiResponse(response);
         if (!response.ok) {
-            const data = await response.json();
+            const data = await response.json().catch(() => ({}));
             throw new Error(data.error || 'Delete failed');
         }
-        // Remove user from the list
-        btn.closest('.list-group-item').remove();
+        const row = btn.closest('.user-row');
+        if (row) row.remove();
     } catch (error) {
         alert(`Error during delete: ${error.message || error}`);
     } finally {
@@ -545,50 +423,48 @@ async function deleteUser(userId, btn) {
     }
 }
 
-// Fetch users when the usersModal is shown
-const usersModal = document.getElementById('usersModal');
-if (usersModal) {
-    usersModal.addEventListener('show.bs.modal', () => {
-        fetchAllUsers();
-    });
+/* ---------------------------------------------------- password reveal */
+function togglePasswordVisibility(inputId, buttonId) {
+    const input = document.getElementById(inputId);
+    const button = document.getElementById(buttonId);
+    if (input && button) {
+        button.addEventListener('click', () => {
+            const show = input.type === 'password';
+            input.type = show ? 'text' : 'password';
+            button.innerHTML = `<i class="bi bi-eye${show ? '-slash' : ''}"></i>`;
+        });
+    }
 }
 
-// Initialize the application
+/* --------------------------------------------------------------- init */
 document.addEventListener('DOMContentLoaded', () => {
-    // Initialize password visibility toggles
+    initTheme();
+
     togglePasswordVisibility('loginPassword', 'toggleLoginPassword');
     togglePasswordVisibility('currentPassword', 'toggleCurrentPassword');
     togglePasswordVisibility('newPassword', 'toggleNewPassword');
     togglePasswordVisibility('newUserPassword', 'toggleNewUserPassword');
 
-    // Handle login
+    // Login
     const loginForm = document.getElementById('loginForm');
     if (loginForm) {
         loginForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const username = document.getElementById('loginUsername').value;
             const password = document.getElementById('loginPassword').value;
-
-            showLoading('Logging in...');
+            showLoading('Signing in…');
             try {
                 const response = await fetch(`${API_URL}/login`, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
+                    headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ username, password })
                 });
-
                 const data = await response.json();
                 if (response.ok) {
-                    // Store only the token
                     localStorage.setItem('token', data.token);
-
                     const modal = bootstrap.Modal.getInstance(document.getElementById('loginModal'));
                     if (modal) modal.hide();
                     loginForm.reset();
-
-                    // Update UI using the new function
                     showAuthenticatedUI();
                     hideLoading();
                 } else {
@@ -602,7 +478,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Handle file upload
+    // Upload
     const uploadForm = document.getElementById('uploadForm');
     const fileInput = document.getElementById('fileInput');
     if (uploadForm && fileInput) {
@@ -610,90 +486,63 @@ document.addEventListener('DOMContentLoaded', () => {
             e.preventDefault();
             const files = fileInput.files;
             if (files.length === 0) return;
-
-            // Check if shared checkbox is checked
             const isShared = document.getElementById('sharedCheckbox')?.checked || false;
             const uploadUrl = `${API_URL}/upload${isShared ? '?shared=true' : ''}`;
 
-            showLoading('Uploading files...');
-            let uploadSuccess = true;
-            // Upload each file individually
-            for (let file of files) {
+            showLoading('Uploading…');
+            let ok = true;
+            for (const file of files) {
                 const formData = new FormData();
                 formData.append('files', file);
-
                 try {
                     const response = await fetch(uploadUrl, {
-                        method: 'POST',
-                        headers: {
-                            'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-                        },
-                        body: formData,
+                        method: 'POST', headers: authHeaders(), body: formData
                     });
-
                     if (!response.ok) {
-                        const data = await response.json();
+                        const data = await response.json().catch(() => ({}));
                         alert(data.error || `Failed to upload ${file.name}`);
-                        uploadSuccess = false;
+                        ok = false;
                     }
                 } catch (error) {
                     console.error('Upload error:', error);
                     alert(`Error uploading ${file.name}`);
-                    uploadSuccess = false;
+                    ok = false;
                 }
             }
-
-            // Clear the input and reload files
             fileInput.value = '';
-            uploadForm.reset(); // Reset the entire form including the shared checkbox
+            uploadForm.reset();
             await loadFiles();
-
-            if (uploadSuccess) {
-                showLoading('Upload successful!');
-                // Wait for 2 seconds before hiding the loading message
-                setTimeout(() => {
-                    hideLoading();
-                }, 2000);
+            if (ok) {
+                showLoading('Uploaded');
+                setTimeout(hideLoading, 1200);
             } else {
                 hideLoading();
             }
         });
     }
 
-    // Handle reset password
+    // Reset password
     const resetPasswordForm = document.getElementById('resetPasswordForm');
     if (resetPasswordForm) {
         resetPasswordForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const currentPassword = document.getElementById('currentPassword').value;
             const newPassword = document.getElementById('newPassword').value;
-
-            // Validate new password length
-            if (newPassword.length < 8) {
-                alert('New password must be at least 8 characters long');
-                return;
-            }
-
-            showLoading('Resetting password...');
+            if (newPassword.length < 8) { alert('New password must be at least 8 characters'); return; }
+            showLoading('Updating password…');
             try {
                 const response = await fetch(`${API_URL}/reset-password`, {
                     method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-                    },
+                    headers: authHeaders({ 'Content-Type': 'application/json' }),
                     body: JSON.stringify({ current_password: currentPassword, new_password: newPassword })
                 });
-
                 const data = await response.json();
                 if (response.ok) {
                     const modal = bootstrap.Modal.getInstance(document.getElementById('resetPasswordModal'));
                     if (modal) modal.hide();
                     resetPasswordForm.reset();
-                    showLoading('Password reset successful!');
-                    setTimeout(() => {
-                        hideLoading();
-                    }, 2000);
+                    showLoading('Password updated');
+                    setTimeout(hideLoading, 1200);
                 } else {
                     throw new Error(data.error || 'Password reset failed');
                 }
@@ -705,7 +554,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Handle create user
+    // Create user
     const createUserForm = document.getElementById('createUserForm');
     if (createUserForm) {
         createUserForm.addEventListener('submit', async (e) => {
@@ -713,33 +562,21 @@ document.addEventListener('DOMContentLoaded', () => {
             const username = document.getElementById('newUsername').value;
             const password = document.getElementById('newUserPassword').value;
             const isAdmin = document.getElementById('isAdminCheckbox').checked;
-
-            // Validate password length
-            if (password.length < 8) {
-                alert('Password must be at least 8 characters long');
-                return;
-            }
-
-            showLoading('Creating user...');
+            if (password.length < 8) { alert('Password must be at least 8 characters'); return; }
+            showLoading('Creating user…');
             try {
                 const response = await fetch(`${API_URL}/signup`, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-                    },
+                    headers: authHeaders({ 'Content-Type': 'application/json' }),
                     body: JSON.stringify({ username, password, is_admin: isAdmin })
                 });
-
                 const data = await response.json();
                 if (response.ok) {
                     const modal = bootstrap.Modal.getInstance(document.getElementById('createUserModal'));
                     if (modal) modal.hide();
                     createUserForm.reset();
-                    showLoading('User created successfully!');
-                    setTimeout(() => {
-                        hideLoading();
-                    }, 2000);
+                    showLoading('User created');
+                    setTimeout(hideLoading, 1200);
                 } else {
                     throw new Error(data.error || 'Failed to create user');
                 }
@@ -751,54 +588,29 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Handle file search
+    // Search
     const fileSearchForm = document.getElementById('fileSearchForm');
     const fileSearchInput = document.getElementById('fileSearchInput');
     if (fileSearchForm && fileSearchInput) {
         fileSearchForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const keyword = fileSearchInput.value.trim();
-            if (!keyword) {
-                // If search is empty, reload all files
-                await loadFiles();
-                return;
-            }
-            showLoading('Searching files...');
+            if (!keyword) { await loadFiles(); return; }
+            showLoading('Searching…');
             try {
-                // Search my files
-                const myFilesResponse = await fetch(`${API_URL}/files?keyword=${encodeURIComponent(keyword)}`, {
-                    headers: {
-                        'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-                    },
-                });
-                handleApiResponse(myFilesResponse);
-                const myFilesData = await myFilesResponse.json();
-                if (!myFilesResponse.ok) {
-                    throw new Error(myFilesData.error || 'Failed to search my files');
-                }
-                const myFilesList = document.getElementById('myFilesList');
-                if (myFilesList) {
-                    displayFiles(myFilesData, myFilesList, 'My Files');
-                }
+                const myResp = await fetch(`${API_URL}/files?keyword=${encodeURIComponent(keyword)}`, { headers: authHeaders() });
+                handleApiResponse(myResp);
+                const myData = await myResp.json();
+                if (!myResp.ok) throw new Error(myData.error || 'Search failed');
+                displayFiles(myData, document.getElementById('myFilesList'),
+                             document.getElementById('myFilesCount'));
 
-                // Search shared files
-                const sharedFilesResponse = await fetch(`${API_URL}/files?shared=true&keyword=${encodeURIComponent(keyword)}`, {
-                    headers: {
-                        'Authorization': `Bearer ${getAuthTokenOrRedirect()}`,
-                    },
-                });
-                fileSearchForm.addEventListener('reset', async () => {
-                    await loadFiles(); // reload all files when reset is clicked
-                });
-                handleApiResponse(sharedFilesResponse);
-                const sharedFilesData = await sharedFilesResponse.json();
-                if (!sharedFilesResponse.ok) {
-                    throw new Error(sharedFilesData.error || 'Failed to search shared files');
-                }
-                const sharedFilesList = document.getElementById('sharedFilesList');
-                if (sharedFilesList) {
-                    displayFiles(sharedFilesData, sharedFilesList, 'Public Files');
-                }
+                const shResp = await fetch(`${API_URL}/files?shared=true&keyword=${encodeURIComponent(keyword)}`, { headers: authHeaders() });
+                handleApiResponse(shResp);
+                const shData = await shResp.json();
+                if (!shResp.ok) throw new Error(shData.error || 'Search failed');
+                displayFiles(shData, document.getElementById('sharedFilesList'),
+                             document.getElementById('sharedFilesCount'));
             } catch (error) {
                 console.error('Error searching files:', error);
                 alert(error.message || 'Error searching files');
@@ -806,8 +618,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 hideLoading();
             }
         });
+        fileSearchForm.addEventListener('reset', () => { loadFiles(); });
     }
 
-    // Check initial authentication status
+    // Users modal
+    const usersModal = document.getElementById('usersModal');
+    if (usersModal) {
+        usersModal.addEventListener('show.bs.modal', fetchAllUsers);
+    }
+
     checkAuth();
-}); 
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,253 +1,248 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="paper">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="CloudBoxIO - Your secure and easy-to-use cloud storage solution">
-    <title>CloudBoxIO - File Storage</title>
-    <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☁️</text></svg>">
-    <!-- Bootstrap CSS -->
+    <meta name="description" content="CloudBoxIO - self-hosted file storage">
+    <title>CloudBoxIO</title>
+    <link rel="icon" type="image/svg+xml"
+          href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☁️</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+    <!-- Bootstrap (used for modals, dropdowns, tooltips + grid utilities) -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
-    <!-- Custom CSS -->
     <link href="styles.css" rel="stylesheet">
 </head>
 <body>
-    <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-        <div class="container">
-            <a class="navbar-brand" href="#">
-                <i class="bi bi-cloud-arrow-up-fill me-2"></i>CloudBoxIO
-            </a>
-            <div class="navbar-nav ms-auto">
-                <!-- User Profile Dropdown (shown when logged in) -->
-                <div class="nav-item d-none" id="userProfileNav">
-                    <div class="dropdown">
-                        <button class="btn btn-link nav-link dropdown-toggle text-light" type="button" id="userProfileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-person-circle me-1"></i>
-                            <span id="navUsername">User</span>
-                        </button>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userProfileDropdown">
-                            <li id="createUserNavItem" style="display: none;"><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#createUserModal">
-                                <i class="bi bi-person-plus me-1"></i>Create User
-                            </button></li>
-                            <li id="createUserDivider" style="display: none;"><hr class="dropdown-divider"></li>
-                            <li id="showUsersPanelNavItem" style="display: none;"><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#usersModal">
-                                <i class="bi bi-people me-1"></i>Show All Users
-                            </button></li>
-                            <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#resetPasswordModal">
-                                <i class="bi bi-key me-1"></i>Reset Password
-                            </button></li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li><button class="dropdown-item text-danger" onclick="logout()">
-                                <i class="bi bi-box-arrow-right me-1"></i>Logout
-                            </button></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </nav>
+    <!-- Compact header -->
+    <header class="app-bar">
+        <a class="brand" href="#">
+            <span class="brand-mark"><i class="bi bi-cloud-arrow-up-fill"></i></span>
+            <span>CloudBoxIO</span>
+        </a>
 
-    <!-- Main Content -->
-    <div class="container mt-4">
-        <!-- Authentication Section (shown when not logged in) -->
+        <div class="app-bar-spacer"></div>
+
+        <div class="theme-switch" role="group" aria-label="Theme">
+            <button type="button" class="ts-btn" data-theme-value="paper" title="Light">
+                <i class="bi bi-sun-fill"></i>
+            </button>
+            <button type="button" class="ts-btn" data-theme-value="carbon" title="Dark">
+                <i class="bi bi-moon-stars-fill"></i>
+            </button>
+            <button type="button" class="ts-btn" data-theme-value="aurora" title="Glass">
+                <i class="bi bi-droplet-half"></i>
+            </button>
+        </div>
+
+        <!-- User menu (shown when logged in) -->
+        <div class="dropdown d-none" id="userProfileNav">
+            <button class="user-menu-btn dropdown-toggle" type="button" id="userProfileDropdown"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-person-circle"></i>
+                <span id="navUsername">User</span>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userProfileDropdown">
+                <li id="createUserNavItem" style="display:none;">
+                    <button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#createUserModal">
+                        <i class="bi bi-person-plus me-1"></i>Create user
+                    </button>
+                </li>
+                <li id="showUsersPanelNavItem" style="display:none;">
+                    <button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#usersModal">
+                        <i class="bi bi-people me-1"></i>Manage users
+                    </button>
+                </li>
+                <li id="createUserDivider" style="display:none;"><hr class="dropdown-divider"></li>
+                <li>
+                    <button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#resetPasswordModal">
+                        <i class="bi bi-key me-1"></i>Reset password
+                    </button>
+                </li>
+                <li><hr class="dropdown-divider"></li>
+                <li>
+                    <button class="dropdown-item text-danger" onclick="logout()">
+                        <i class="bi bi-box-arrow-right me-1"></i>Log out
+                    </button>
+                </li>
+            </ul>
+        </div>
+    </header>
+
+    <div class="container mt-3 mt-md-4">
+        <!-- Logged-out -->
         <div id="authSection">
-            <!-- Welcome Section -->
-            <div id="welcomeSection" class="welcome-section">
-                <div class="welcome-content">
-                    <h1>Welcome to CloudBoxIO</h1>
-                    <p>Your secure and easy-to-use cloud storage solution</p>
-                    <div class="welcome-buttons">
-                        <button class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#loginModal">
-                            <i class="bi bi-box-arrow-in-right me-1"></i>Login
-                        </button>
-                    </div>
-                </div>
+            <div class="welcome">
+                <div class="glyph"><i class="bi bi-cloud-arrow-up-fill"></i></div>
+                <h1>CloudBoxIO</h1>
+                <p>Self-hosted file storage. Sign in to continue.</p>
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#loginModal">
+                    <i class="bi bi-box-arrow-in-right me-1"></i>Log in
+                </button>
             </div>
         </div>
 
-        <!-- Main Section (shown when logged in) -->
-        <div id="mainSection" style="display: none;">
-            <!-- File Upload Section -->
-            <div class="card mb-4" id="uploadSection">
-                <div class="card-body">
-                    <h5 class="card-title">Upload Files</h5>
-                    <form id="uploadForm">
-                        <div class="mb-3">
-                            <input type="file" class="form-control" id="fileInput" multiple>
-                        </div>
-                        <div class="mb-3 form-check">
-                            <input type="checkbox" class="form-check-input" id="sharedCheckbox">
-                            <label class="form-check-label" for="sharedCheckbox">Make selected files public</label>
-                        </div>
-                        <button type="submit" class="btn btn-primary w-100 w-md-auto">Upload</button>
-                    </form>
-                </div>
+        <!-- Logged-in -->
+        <div id="mainSection" style="display:none;" class="stack">
+            <!-- Upload bar -->
+            <div class="panel panel-pad">
+                <div class="panel-title"><i class="bi bi-upload"></i> Upload</div>
+                <form id="uploadForm" class="upload-bar">
+                    <input type="file" class="field file-field" id="fileInput" multiple>
+                    <label class="shared-toggle">
+                        <input type="checkbox" id="sharedCheckbox"> Make public
+                    </label>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-cloud-arrow-up me-1"></i>Upload
+                    </button>
+                </form>
             </div>
 
-            <!-- File Search Bar -->
-            <form id="fileSearchForm" class="mb-3 d-flex" autocomplete="off">
-                <input type="text" class="form-control me-2" id="fileSearchInput" placeholder="Search files by name...">
+            <!-- Search -->
+            <form id="fileSearchForm" class="search-bar" autocomplete="off">
+                <input type="text" class="field" id="fileSearchInput" placeholder="Search files by name…">
                 <button type="submit" class="btn btn-primary">Search</button>
-                <button type="reset" class="btn btn-secondary ms-2">Clear</button>
+                <button type="reset" class="btn btn-ghost">Clear</button>
             </form>
-`
-            <!-- Files List Section -->
-            <div class="card" id="filesSection">
-                <div class="card-body">
-                    <div class="row g-4">
-                        <!-- My Files Section -->
-                        <div class="col-12 col-md-6">
-                            <div class="card h-100">
-                                <div class="card-body">
-                                    <h5 class="card-title mb-3">My Files</h5>
-                                    <div id="myFilesList" class="list-group">
-                                        <!-- My files will be listed here -->
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Shared Files Section -->
-                        <div class="col-12 col-md-6">
-                            <div class="card h-100">
-                                <div class="card-body">
-                                    <h5 class="card-title mb-3">Public Files</h5>
-                                    <div id="sharedFilesList" class="list-group">
-                                        <!-- Shared files will be listed here -->
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+
+            <!-- Files -->
+            <div class="file-grid">
+                <div class="panel panel-pad">
+                    <div class="panel-title">
+                        <i class="bi bi-folder"></i> My files
+                        <span class="count" id="myFilesCount">0</span>
                     </div>
+                    <div id="myFilesList" class="file-list"></div>
+                </div>
+                <div class="panel panel-pad">
+                    <div class="panel-title">
+                        <i class="bi bi-globe2"></i> Public files
+                        <span class="count" id="sharedFilesCount">0</span>
+                    </div>
+                    <div id="sharedFilesList" class="file-list"></div>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Login Modal -->
+    <!-- Login modal -->
     <div class="modal fade" id="loginModal" tabindex="-1">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Login</h5>
+                    <h5 class="modal-title">Log in</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <form id="loginForm">
-                        <div class="mb-3">
+                        <div class="form-row">
                             <label for="loginUsername" class="form-label">Username</label>
-                            <input type="text" class="form-control" id="loginUsername" required>
+                            <input type="text" class="field" id="loginUsername" required>
                         </div>
-                        <div class="mb-3">
+                        <div class="form-row">
                             <label for="loginPassword" class="form-label">Password</label>
-                            <div class="input-group">
-                                <input type="password" class="form-control" id="loginPassword" required>
-                                <button class="btn btn-outline-secondary" type="button" id="toggleLoginPassword">
-                                    <i class="bi bi-eye"></i>
-                                </button>
+                            <div class="input-wrap">
+                                <input type="password" class="field" id="loginPassword" required>
+                                <button class="reveal" type="button" id="toggleLoginPassword"><i class="bi bi-eye"></i></button>
                             </div>
                         </div>
-                        <button type="submit" class="btn btn-primary w-100">Login</button>
+                        <button type="submit" class="btn btn-primary btn-block">Log in</button>
                     </form>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Reset Password Modal -->
+    <!-- Reset password modal -->
     <div class="modal fade" id="resetPasswordModal" tabindex="-1">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Reset Password</h5>
+                    <h5 class="modal-title">Reset password</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <form id="resetPasswordForm">
-                        <div class="mb-3">
-                            <label for="currentPassword" class="form-label">Current Password</label>
-                            <div class="input-group">
-                                <input type="password" class="form-control" id="currentPassword" required>
-                                <button class="btn btn-outline-secondary" type="button" id="toggleCurrentPassword">
-                                    <i class="bi bi-eye"></i>
-                                </button>
+                        <div class="form-row">
+                            <label for="currentPassword" class="form-label">Current password</label>
+                            <div class="input-wrap">
+                                <input type="password" class="field" id="currentPassword" required>
+                                <button class="reveal" type="button" id="toggleCurrentPassword"><i class="bi bi-eye"></i></button>
                             </div>
                         </div>
-                        <div class="mb-3">
-                            <label for="newPassword" class="form-label">New Password</label>
-                            <div class="input-group">
-                                <input type="password" class="form-control" id="newPassword" required minlength="8">
-                                <button class="btn btn-outline-secondary" type="button" id="toggleNewPassword">
-                                    <i class="bi bi-eye"></i>
-                                </button>
+                        <div class="form-row">
+                            <label for="newPassword" class="form-label">New password</label>
+                            <div class="input-wrap">
+                                <input type="password" class="field" id="newPassword" required minlength="8">
+                                <button class="reveal" type="button" id="toggleNewPassword"><i class="bi bi-eye"></i></button>
                             </div>
-                            <div class="form-text">Password must be at least 8 characters long</div>
+                            <div class="form-hint">At least 8 characters.</div>
                         </div>
-                        <button type="submit" class="btn btn-primary w-100">Reset Password</button>
+                        <button type="submit" class="btn btn-primary btn-block">Reset password</button>
                     </form>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Create User Modal -->
+    <!-- Create user modal -->
     <div class="modal fade" id="createUserModal" tabindex="-1">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Create New User</h5>
+                    <h5 class="modal-title">Create user</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <form id="createUserForm">
-                        <div class="mb-3">
+                        <div class="form-row">
                             <label for="newUsername" class="form-label">Username</label>
-                            <input type="text" class="form-control" id="newUsername" required>
+                            <input type="text" class="field" id="newUsername" required>
                         </div>
-                        <div class="mb-3">
+                        <div class="form-row">
                             <label for="newUserPassword" class="form-label">Password</label>
-                            <div class="input-group">
-                                <input type="password" class="form-control" id="newUserPassword" required minlength="8">
-                                <button class="btn btn-outline-secondary" type="button" id="toggleNewUserPassword">
-                                    <i class="bi bi-eye"></i>
-                                </button>
+                            <div class="input-wrap">
+                                <input type="password" class="field" id="newUserPassword" required minlength="8">
+                                <button class="reveal" type="button" id="toggleNewUserPassword"><i class="bi bi-eye"></i></button>
                             </div>
-                            <div class="form-text">Password must be at least 8 characters long</div>
+                            <div class="form-hint">At least 8 characters.</div>
                         </div>
-                        <div class="mb-3 form-check">
-                            <input type="checkbox" class="form-check-input" id="isAdminCheckbox">
-                            <label class="form-check-label" for="isAdminCheckbox">Make this user an admin</label>
-                        </div>
-                        <button type="submit" class="btn btn-primary w-100">Create User</button>
+                        <label class="check form-row">
+                            <input type="checkbox" id="isAdminCheckbox"> Grant admin rights
+                        </label>
+                        <button type="submit" class="btn btn-primary btn-block">Create user</button>
                     </form>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Users Modal (admin only) -->
+    <!-- Users modal (admin) -->
     <div class="modal fade" id="usersModal" tabindex="-1">
         <div class="modal-dialog modal-dialog-centered modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">All Users</h5>
+                    <h5 class="modal-title">Users</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
-                    <div id="usersList" class="list-group">
-                        <!-- User list will be rendered here -->
-                    </div>
+                    <div id="usersList"></div>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Bootstrap JS -->
+    <!-- Loading overlay -->
+    <div class="loading-overlay" id="loadingOverlay">
+        <div class="loading-card">
+            <div class="spinner"></div>
+            <div class="loading-msg" id="loadingMsg">Loading…</div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Custom JS -->
     <script src="app.js"></script>
 </body>
-</html> 
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,579 +1,539 @@
-/* Base styles */
+/* =========================================================================
+   CloudBoxIO — UI theme system
+   Three themes driven by [data-theme] on <html>:
+     paper   → light, thin blue accent (refined original)
+     carbon  → dark, GitHub/Telegram-like
+     aurora  → frosted "liquid glass" / acrylic
+   Design intent: dense, utilitarian, developer-tool feel. Monospace metadata,
+   hairline borders instead of heavy shadows, compact rows.
+   ========================================================================= */
+
+/* ---- Paper (default / light) ---- */
+:root,
+:root[data-theme="paper"] {
+  --font-sans: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+
+  --bg: #eef1f6;
+  --bg-elev: #ffffff;
+  --bg-elev-2: #f5f7fb;
+  --border: #dfe4ec;
+  --border-strong: #c7cdd9;
+  --text: #1b2432;
+  --text-dim: #6a7686;
+  --accent: #2f6bff;
+  --accent-hover: #2359e0;
+  --accent-contrast: #ffffff;
+  --accent-soft: rgba(47, 107, 255, 0.10);
+  --danger: #e5484d;
+  --danger-soft: rgba(229, 72, 77, 0.10);
+  --warn: #d68a00;
+
+  --header-bg: linear-gradient(90deg, #2f6bff, #4a7dff);
+  --header-fg: #ffffff;
+  --header-border: transparent;
+  --row-hover: #f1f4fa;
+  --radius: 0px;
+  --radius-sm: 0px;
+  --shadow: 0 1px 2px rgba(20, 30, 50, 0.06), 0 2px 8px rgba(20, 30, 50, 0.04);
+  --panel-blur: none;
+  --body-bg-image: none;
+}
+
+/* ---- Carbon (dark, github/telegram) ---- */
+:root[data-theme="carbon"] {
+  --bg: #0d1117;
+  --bg-elev: #161b22;
+  --bg-elev-2: #1c2230;
+  --border: #2b3240;
+  --border-strong: #3a4252;
+  --text: #e6edf3;
+  --text-dim: #8b949e;
+  --accent: #4c9aff;
+  --accent-hover: #61a8ff;
+  --accent-contrast: #08111f;
+  --accent-soft: rgba(76, 154, 255, 0.14);
+  --danger: #f85149;
+  --danger-soft: rgba(248, 81, 73, 0.14);
+  --warn: #e3b341;
+
+  --header-bg: #161b22;
+  --header-fg: #e6edf3;
+  --header-border: #2b3240;
+  --row-hover: #1b222d;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --panel-blur: none;
+  --body-bg-image: none;
+}
+
+/* ---- Aurora (frosted glass / acrylic) ---- */
+:root[data-theme="aurora"] {
+  --bg: #10142b;
+  --bg-elev: rgba(255, 255, 255, 0.09);
+  --bg-elev-2: rgba(255, 255, 255, 0.055);
+  --border: rgba(255, 255, 255, 0.16);
+  --border-strong: rgba(255, 255, 255, 0.28);
+  --text: #f2f5ff;
+  --text-dim: rgba(226, 232, 255, 0.66);
+  --accent: #8aa8ff;
+  --accent-hover: #a0baff;
+  --accent-contrast: #10142b;
+  --accent-soft: rgba(138, 168, 255, 0.20);
+  --danger: #ff8085;
+  --danger-soft: rgba(255, 128, 133, 0.16);
+  --warn: #ffcf6b;
+
+  --header-bg: rgba(255, 255, 255, 0.07);
+  --header-fg: #f2f5ff;
+  --header-border: rgba(255, 255, 255, 0.14);
+  --row-hover: rgba(255, 255, 255, 0.07);
+  --shadow: 0 8px 30px rgba(6, 10, 30, 0.35);
+  --panel-blur: saturate(150%) blur(18px);
+  --body-bg-image:
+    radial-gradient(60vw 60vw at 12% -10%, rgba(120, 90, 255, 0.55), transparent 60%),
+    radial-gradient(55vw 55vw at 100% 10%, rgba(0, 190, 200, 0.42), transparent 58%),
+    radial-gradient(60vw 60vw at 50% 120%, rgba(255, 90, 190, 0.40), transparent 60%);
+}
+
+/* ------------------------------------------------------------------ base */
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
 body {
-    background-color: #e9ecef;
-    min-height: 100vh;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image: var(--body-bg-image);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
 }
 
-/* Navbar styles */
-.navbar {
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    padding: 1rem 0;
-    position: relative;
+.container { max-width: 900px; }
+
+::selection { background: var(--accent-soft); }
+
+/* ----------------------------------------------------------------- header */
+.app-bar {
+  position: sticky;
+  top: 0;
+  z-index: 1030;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  background: var(--header-bg);
+  color: var(--header-fg);
+  border-bottom: 1px solid var(--header-border);
+  backdrop-filter: var(--panel-blur);
+  -webkit-backdrop-filter: var(--panel-blur);
 }
 
-.navbar .container {
-    position: relative;
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  font-size: 0.95rem;
+  color: var(--header-fg);
+  text-decoration: none;
+}
+.brand-mark {
+  width: 26px; height: 26px;
+  flex: none;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 0.98rem;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.26);
+}
+:root[data-theme="carbon"] .brand-mark {
+  background: var(--accent-soft);
+  border-color: var(--border-strong);
+  color: var(--accent);
+}
+:root[data-theme="aurora"] .brand-mark { background: rgba(255, 255, 255, 0.14); }
+
+.app-bar-spacer { flex: 1; }
+
+/* theme switcher */
+.theme-switch {
+  display: inline-flex;
+  padding: 2px;
+  gap: 2px;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+:root[data-theme="paper"] .theme-switch { background: rgba(255,255,255,0.18); border-color: rgba(255,255,255,0.28); }
+:root[data-theme="carbon"] .theme-switch { background: var(--bg-elev-2); border-color: var(--border); }
+:root[data-theme="aurora"] .theme-switch { background: rgba(255,255,255,0.10); }
+
+.ts-btn {
+  border: 0;
+  background: transparent;
+  color: var(--header-fg);
+  width: 28px; height: 24px;
+  cursor: pointer;
+  opacity: 0.7;
+  font-size: 0.82rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background .12s, opacity .12s;
+}
+.ts-btn:hover { opacity: 1; }
+.ts-btn.active {
+  opacity: 1;
+  background: rgba(255,255,255,0.28);
+}
+:root[data-theme="carbon"] .ts-btn.active { background: var(--accent-soft); color: var(--accent); }
+:root[data-theme="aurora"] .ts-btn.active { background: rgba(255,255,255,0.22); }
+
+/* user menu button in header */
+.user-menu-btn {
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.28);
+  color: var(--header-fg);
+  padding: 3px 10px 3px 8px;
+  font-size: 0.82rem;
+  display: inline-flex; align-items: center; gap: 6px;
+  cursor: pointer;
+}
+:root[data-theme="carbon"] .user-menu-btn,
+:root[data-theme="aurora"] .user-menu-btn { border-color: var(--border-strong); }
+.user-menu-btn:hover { background: rgba(255,255,255,0.14); }
+
+/* -------------------------------------------------------------- surfaces */
+.panel {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  backdrop-filter: var(--panel-blur);
+  -webkit-backdrop-filter: var(--panel-blur);
+}
+.panel-pad { padding: 14px 16px; }
+
+.panel-title {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  font-weight: 600;
+  margin: 0 0 10px;
+  display: flex; align-items: center; gap: 6px;
+}
+.panel-title .count {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  padding: 0 7px;
+  font-size: 0.66rem;
+  color: var(--text-dim);
 }
 
-.navbar-brand {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: #fff !important;
+/* ------------------------------------------------------------- upload bar */
+.upload-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+.upload-bar .file-field { flex: 1 1 240px; min-width: 0; }
+.upload-bar .shared-toggle {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 0.8rem; color: var(--text-dim);
+  white-space: nowrap; cursor: pointer;
+  user-select: none;
 }
 
-.nav-link {
-    font-weight: 500;
-    padding: 0.5rem 1rem !important;
-    border-radius: 0.25rem;
-    transition: all 0.2s ease;
+/* -------------------------------------------------------------- file list */
+.file-list { display: flex; flex-direction: column; }
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  border-bottom: 1px solid var(--border);
+}
+.file-row:last-child { border-bottom: 0; }
+.file-row:hover { background: var(--row-hover); }
+
+.file-icon {
+  flex: none;
+  width: 20px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 1.02rem;
+}
+.file-main { min-width: 0; flex: 1; }
+.file-name {
+  font-size: 0.85rem;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.file-meta {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+.file-meta .sep { opacity: 0.5; padding: 0 2px; }
+
+.file-actions {
+  flex: none;
+  display: flex;
+  gap: 4px;
+  opacity: 0.5;
+  transition: opacity .12s;
+}
+.file-row:hover .file-actions,
+.file-row:focus-within .file-actions { opacity: 1; }
+
+.icon-btn {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-dim);
+  width: 28px; height: 28px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 0.9rem;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.icon-btn:hover { background: var(--accent-soft); color: var(--accent); border-color: var(--border); }
+.icon-btn.danger:hover { background: var(--danger-soft); color: var(--danger); }
+
+.empty-row {
+  padding: 16px 8px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 0.8rem;
 }
 
-.nav-link:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+/* ------------------------------------------------------------ welcome/lo */
+.welcome {
+  text-align: center;
+  padding: 64px 20px;
 }
-
-#loginNav .nav-link {
-    background-color: #fff;
-    color: #3498db !important;
+.welcome .glyph {
+  width: 58px; height: 58px;
+  margin: 0 auto 14px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.9rem;
+  color: var(--accent);
+  border: 1px solid var(--border-strong);
+  background: var(--accent-soft);
 }
-
-#loginNav .nav-link:hover {
-    background-color: #f8f9fa;
+.welcome h1 {
+  font-family: var(--font-mono);
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0 0 6px;
+  letter-spacing: 0.01em;
 }
+.welcome p { color: var(--text-dim); margin: 0 0 20px; }
 
-#signupNav .nav-link {
-    background-color: #2ecc71;
-    color: #fff !important;
-    margin-left: 0.5rem;
+/* ------------------------------------------------------------- controls */
+.btn {
+  --btn-bg: var(--bg-elev-2);
+  --btn-fg: var(--text);
+  --btn-border: var(--border-strong);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--btn-border);
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  padding: 7px 14px;
+  cursor: pointer;
+  transition: background .12s, border-color .12s, color .12s, transform .04s;
 }
+.btn:active { transform: translateY(1px); }
+.btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
-#signupNav .nav-link:hover {
-    background-color: #27ae60;
-}
-
-#logoutNav .btn {
-    padding: 0.5rem 1.25rem;
-    font-weight: 500;
-    border-radius: 0.25rem;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-#logoutNav .btn-danger {
-    background-color: #e74c3c;
-    border-color: #e74c3c;
-}
-
-#logoutNav .btn-danger:hover {
-    background-color: #c0392b;
-    border-color: #c0392b;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-
-#logoutNav .btn i {
-    font-size: 1.1rem;
-}
-
-/* Welcome section */
-.welcome-section {
-    text-align: center;
-    padding: 3rem 1rem;
-    background: linear-gradient(135deg, #3498db, #2ecc71);
-    color: white;
-    margin: 2rem 0;
-    border-radius: 1rem;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-}
-
-.welcome-content {
-    max-width: 800px;
-    margin: 0 auto;
-}
-
-.welcome-section h1 {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-}
-
-.welcome-section p {
-    font-size: 1.2rem;
-    margin-bottom: 2rem;
-    opacity: 0.9;
-}
-
-.welcome-buttons {
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-    flex-wrap: wrap;
-}
-
-.welcome-section .btn {
-    padding: 0.75rem 2rem;
-    font-size: 1.1rem;
-    font-weight: 500;
-    min-width: 160px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-}
-
-.welcome-section .btn-outline-light {
-    border-width: 2px;
-    transition: all 0.3s ease;
-}
-
-.welcome-section .btn-outline-light:hover {
-    background-color: #fff;
-    color: #3498db;
-    transform: translateY(-2px);
-}
-
-/* Card and list styles */
-.card {
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-    border: none;
-    margin-bottom: 1rem;
-}
-
-.card-title {
-    color: #2c3e50;
-    font-weight: 600;
-}
-
-.list-group-item {
-    border: none;
-    border-bottom: 1px solid #eee;
-    padding: 1rem;
-}
-
-.list-group-item:last-child {
-    border-bottom: none;
-}
-
-.list-group-item strong {
-    font-size: 0.9rem;
-}
-
-.list-group-item small {
-    font-size: 0.8rem;
-}
-
-/* Button styles */
 .btn-primary {
-    background-color: #3498db;
-    border-color: #3498db;
+  --btn-bg: var(--accent);
+  --btn-fg: var(--accent-contrast);
+  --btn-border: transparent;
+}
+.btn-primary:hover { background: var(--accent-hover); }
+
+.btn-ghost { --btn-bg: transparent; --btn-border: var(--border); }
+.btn-ghost:hover { background: var(--bg-elev-2); }
+
+.btn-danger { --btn-bg: transparent; --btn-fg: var(--danger); --btn-border: var(--danger); }
+.btn-danger:hover { background: var(--danger-soft); }
+
+.btn-block { width: 100%; }
+
+/* inputs */
+.field {
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  color: var(--text);
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 7px 10px;
+  transition: border-color .12s, box-shadow .12s;
+}
+.field::placeholder { color: var(--text-dim); }
+.field:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+input[type="file"].field { padding: 6px 8px; }
+input[type="file"].field::file-selector-button {
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  margin-right: 10px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elev);
+  color: var(--text);
+  cursor: pointer;
 }
 
-.btn-primary:hover {
-    background-color: #2980b9;
-    border-color: #2980b9;
+.input-wrap { position: relative; display: flex; }
+.input-wrap .field { padding-right: 38px; }
+.input-wrap .reveal {
+  position: absolute; right: 4px; top: 50%; transform: translateY(-50%);
+  border: 0; background: transparent; color: var(--text-dim);
+  width: 30px; height: 30px; border-radius: var(--radius-sm); cursor: pointer;
+}
+.input-wrap .reveal:hover { color: var(--text); }
+
+.form-row { margin-bottom: 14px; }
+.form-label {
+  display: block;
+  font-size: 0.74rem;
+  color: var(--text-dim);
+  margin-bottom: 5px;
+  letter-spacing: 0.02em;
+}
+.form-hint { font-size: 0.7rem; color: var(--text-dim); margin-top: 5px; }
+
+.check {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 0.82rem; cursor: pointer; user-select: none;
+}
+.check input { accent-color: var(--accent); width: 15px; height: 15px; }
+
+.badge-admin {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--warn);
+  border: 1px solid var(--warn);
+  padding: 0 6px;
+  margin-left: 6px;
 }
 
-/* File upload area */
-#fileInput {
-    border: 2px dashed #ddd;
-    padding: 20px;
-    text-align: center;
-    cursor: pointer;
+/* two-column file area */
+.file-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
 }
 
-#fileInput:hover {
-    border-color: #3498db;
-}
+.search-bar { display: flex; gap: 8px; margin-bottom: 14px; }
+.search-bar .field { flex: 1; }
 
-/* File list item layout */
-.list-group-item .d-flex {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    width: 100%;
-    flex-wrap: wrap;
-}
+.stack > * + * { margin-top: 14px; }
 
-.list-group-item .file-name {
-    flex: 1;
-    min-width: 200px;
+/* ------------------------------------------------------- bootstrap modal */
+.modal-content {
+  background: var(--bg-elev);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  backdrop-filter: var(--panel-blur);
+  -webkit-backdrop-filter: var(--panel-blur);
 }
+.modal-header, .modal-footer { border-color: var(--border); }
+.modal-title { font-size: 0.98rem; font-weight: 600; }
+.btn-close { filter: var(--btn-close-filter, none); }
+:root[data-theme="carbon"] .btn-close,
+:root[data-theme="aurora"] .btn-close { filter: invert(1) grayscale(1) brightness(1.4); }
+.modal-backdrop.show { opacity: 0.55; }
 
-.list-group-item .btn-group {
-    display: flex;
-    gap: 0.5rem;
+/* user list rows inside modal */
+.user-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px; padding: 8px 6px; border-bottom: 1px solid var(--border);
 }
+.user-row:last-child { border-bottom: 0; }
+.user-row .uname { font-size: 0.86rem; }
 
-.btn-group .btn {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
+/* dropdown (bootstrap) theming */
+.dropdown-menu {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  font-size: 0.85rem;
+  backdrop-filter: var(--panel-blur);
+  -webkit-backdrop-filter: var(--panel-blur);
 }
+.dropdown-item { color: var(--text); border-radius: var(--radius-sm); }
+.dropdown-item:hover { background: var(--bg-elev-2); color: var(--text); }
+.dropdown-item.text-danger { color: var(--danger) !important; }
+.dropdown-item.text-danger:hover { background: var(--danger-soft); }
+.dropdown-divider { border-color: var(--border); }
 
-.btn-group .btn i {
-    font-size: 1rem;
-}
-
-/* Mobile dropdown */
-.mobile-dropdown {
-    display: none;
-}
-
-.mobile-dropdown .dropdown-menu {
-    min-width: 200px;
-    padding: 0.5rem 0;
-}
-
-.mobile-dropdown .dropdown-item {
-    padding: 0.5rem 1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.mobile-dropdown .dropdown-item:hover {
-    background-color: #f8f9fa;
-}
-
-.mobile-dropdown .dropdown-item.text-danger:hover {
-    background-color: #fee2e2;
-}
-
-.mobile-dropdown .dropdown-item i {
-    font-size: 1rem;
-    width: 1.25rem;
-    text-align: center;
-}
-
-/* Form styles */
-.form-control {
-    border-radius: 0.375rem;
-}
-
-.input-group .btn-outline-secondary {
-    border-color: #ced4da;
-    color: #6c757d;
-}
-
-.input-group .btn-outline-secondary:hover {
-    background-color: #f8f9fa;
-    border-color: #ced4da;
-    color: #495057;
-}
-
-.input-group .btn-outline-secondary:focus {
-    box-shadow: none;
-}
-
-.input-group .btn-outline-secondary i {
-    font-size: 1rem;
-}
-
-.form-check {
-    margin-top: 0.5rem;
-}
-
-/* Modal styles */
-.modal-dialog {
-    margin: 1.75rem auto;
-}
-
-/* User Details Styles */
-#userDetailsSection {
-    margin-bottom: 2rem;
-}
-
-#userDetails .card {
-    border: none;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    border-radius: 8px;
-}
-
-#userDetails .card-body {
-    padding: 1.5rem;
-}
-
-#userDetails .card-title {
-    color: #333;
-    margin-bottom: 1.5rem;
-    font-weight: 600;
-}
-
-#userDetails .user-info p {
-    margin-bottom: 0.75rem;
-    color: #555;
-}
-
-#userDetails .user-info strong {
-    color: #333;
-    margin-right: 0.5rem;
-}
-
-/* User Profile Dropdown Styles */
-#userProfileNav {
-    position: static;
-}
-
-#userProfileNav .dropdown {
-    position: static;
-}
-
-#userProfileNav .dropdown-toggle {
-    text-decoration: none;
-    padding: 0.75rem 1.25rem;
-    font-size: 1.1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    white-space: nowrap;
-}
-
-#userProfileNav .dropdown-toggle .badge {
-    font-size: 0.7rem;
-    padding: 0.25em 0.5em;
-    margin-left: 0.5rem;
-    vertical-align: middle;
-}
-
-#userProfileNav .dropdown-toggle i {
-    font-size: 1.3rem;
-}
-
-#userProfileNav .dropdown-toggle:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-    border-radius: 4px;
-}
-
-#userProfileNav .dropdown-menu {
-    min-width: 280px;
-    padding: 1rem 0;
-    margin-top: 0.5rem;
-    border: none;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    position: absolute;
-    right: 1rem;
-    left: auto;
-    transform: none !important;
-}
-
-#userProfileNav .dropdown-item-text {
-    padding: 0.75rem 1.25rem;
-    font-size: 0.95rem;
-    color: #666;
-    border-bottom: 1px solid #eee;
-    margin-bottom: 0.5rem;
-    white-space: normal;
-    word-break: break-word;
-}
-
-#userProfileNav .dropdown-item {
-    padding: 0.75rem 1.25rem;
-    display: flex;
-    align-items: center;
-    font-size: 0.95rem;
-    white-space: nowrap;
-}
-
-#userProfileNav .dropdown-item i {
-    margin-right: 0.75rem;
-    font-size: 1.1rem;
-    flex-shrink: 0;
-}
-
-#userProfileNav .dropdown-item:hover {
-    background-color: #f8f9fa;
-}
-
-#userProfileNav .dropdown-item.text-danger:hover {
-    background-color: #dc3545;
-    color: white !important;
-}
-
-/* Loading overlay styles */
+/* ----------------------------------------------------------- loading */
 .loading-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
+  position: fixed; inset: 0;
+  background: rgba(8, 12, 24, 0.45);
+  display: none; align-items: center; justify-content: center;
+  z-index: 3000;
+  backdrop-filter: blur(2px);
 }
-
-.loading-content {
-    background-color: white;
-    padding: 2rem;
-    border-radius: 8px;
-    text-align: center;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+.loading-overlay.show { display: flex; }
+.loading-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px 26px;
+  text-align: center;
+  color: var(--text);
+  box-shadow: var(--shadow);
+  min-width: 180px;
 }
-
-.loading-message {
-    color: #666;
-    margin-top: 1rem;
+.spinner {
+  width: 26px; height: 26px; margin: 0 auto 10px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
 }
+@keyframes spin { to { transform: rotate(360deg); } }
+.loading-msg { font-size: 0.82rem; color: var(--text-dim); }
 
-/* Filename display styles */
-.desktop-filename {
-    display: inline;
-}
-
-.mobile-filename {
-    display: none;
-}
-
-/* Responsive styles */
-@media (max-width: 991px) {
-    .list-group-item .d-flex {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .list-group-item .file-name {
-        margin-bottom: 0.5rem;
-    }
-
-    .btn-group .btn {
-        flex: 1;
-    }
-
-    .btn-group .btn i {
-        margin-right: 0.25rem;
-    }
-
-    #userProfileNav .dropdown-toggle {
-        padding: 0.5rem 1rem;
-        font-size: 1rem;
-    }
-
-    #userProfileNav .dropdown-menu {
-        min-width: 250px;
-        padding: 0.75rem 0;
-        margin-top: 0.25rem;
-        right: 0.5rem;
-    }
-
-    #userProfileNav .dropdown-item-text {
-        padding: 0.75rem 1rem;
-        font-size: 0.9rem;
-    }
-
-    #userProfileNav .dropdown-item {
-        padding: 0.75rem 1rem;
-        font-size: 0.9rem;
-    }
-}
-
-@media (max-width: 768px) {
-    .container {
-        padding: 0 1rem;
-    }
-
-    .card-body {
-        padding: 1rem;
-    }
-
-    .list-group-item {
-        padding: 0.75rem;
-    }
-
-    .list-group-item .d-flex {
-        gap: 0.5rem;
-    }
-
-    .list-group-item .btn-group {
-        display: none;
-    }
-
-    .list-group-item .mobile-dropdown {
-        display: block;
-        width: 100%;
-    }
-
-    .list-group-item .mobile-dropdown .dropdown-toggle {
-        width: 100%;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.5rem 0.75rem;
-        font-size: 0.875rem;
-    }
-
-    .list-group-item .mobile-dropdown .dropdown-toggle::after {
-        margin-left: 0.5rem;
-    }
-
-    .welcome-section {
-        margin: 1rem 0;
-        padding: 2rem 1rem;
-        border-radius: 0.5rem;
-    }
-
-    .welcome-section h1 {
-        font-size: 2rem;
-    }
-
-    .welcome-section p {
-        font-size: 1.1rem;
-        padding: 0 1rem;
-    }
-
-    .welcome-buttons {
-        flex-direction: column;
-        gap: 0.75rem;
-        padding: 0 1rem;
-    }
-
-    .welcome-section .btn {
-        width: 100%;
-        padding: 0.875rem 1.5rem;
-    }
-
-    .desktop-filename {
-        display: none;
-    }
-
-    .mobile-filename {
-        display: inline;
-    }
-
-    #userProfileNav .dropdown-toggle {
-        padding: 0.5rem 0.75rem;
-    }
-
-    #userProfileNav .dropdown-menu {
-        min-width: 220px;
-        padding: 0.5rem 0;
-        right: 0.25rem;
-    }
-
-    #userProfileNav .dropdown-item-text {
-        padding: 0.5rem 0.75rem;
-    }
-
-    #userProfileNav .dropdown-item {
-        padding: 0.5rem 0.75rem;
-    }
-}
-
-@media (min-width: 769px) {
-    .list-group-item .mobile-dropdown {
-        display: none;
-    }
-
-    .list-group-item .btn-group {
-        display: flex;
-    }
-}
-
-@media (min-width: 576px) {
-    .modal-dialog {
-        max-width: 500px;
-        margin: 1.75rem auto;
-    }
+/* ------------------------------------------------------------ responsive */
+@media (max-width: 720px) {
+  .file-grid { grid-template-columns: 1fr; }
+  .container { padding-left: 12px; padding-right: 12px; }
+  .file-meta .uploader { display: none; }
 }

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -48,6 +48,11 @@ func (h *AuthHandler) SignUp(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Username and password are required"})
 	}
 
+	// Validate password length
+	if len(req.Password) < 8 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Password must be at least 8 characters"})
+	}
+
 	// Generate the hash for the password.
 	hashedpwd, err := bcrypt.GenerateFromPassword([]byte(req.Password), 14)
 	if err != nil {
@@ -109,7 +114,7 @@ func (h *AuthHandler) Login(c *fiber.Ctx) error {
 	}
 
 	// Generate JWT
-	token, err := internal.GenerateToken(userID, is_admin, 72)
+	token, err := internal.GenerateToken(userID, is_admin, internal.TokenExpiryHours())
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to generate token"})
 	}

--- a/handlers/auth_policy_test.go
+++ b/handlers/auth_policy_test.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AumSahayata/cloudboxio/internal"
+	"github.com/AumSahayata/cloudboxio/tests"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Signup must reject passwords shorter than 8 characters.
+func TestSignup_RejectsWeakPassword(t *testing.T) {
+	ctx := SetupTestContext(t)
+	tests.SetAdminSetupFlag(ctx.DB, true)
+
+	handler := NewAuthHandler(ctx.DB, ctx.Log, ctx.Log)
+	ctx.App.Use(internal.JWTProtected())
+	ctx.App.Post("/signup", handler.SignUp)
+
+	body, _ := json.Marshal(map[string]any{
+		"username": "weakling",
+		"password": "123",
+		"is_admin": false,
+	})
+	req := httptest.NewRequest("POST", "/signup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.Token)
+
+	resp, err := ctx.App.Test(req, -1)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400 for weak password, got %d", resp.StatusCode)
+	}
+}

--- a/handlers/file.go
+++ b/handlers/file.go
@@ -38,21 +38,24 @@ func (h *FileHandler) UploadFile(c *fiber.Ctx) error {
 
 	// Create shared folder if not exists
 	dirPath := filepath.Join(fileDir, sharedDir)
-	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(dirPath, 0o750); err != nil {
 		return fmt.Errorf("failed to create shared dir: %w", err)
 	}
 
 	if !isShared {
 		// Create user's folder if not exists
 		dirPath = filepath.Join(fileDir, userID)
-		if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		if err := os.MkdirAll(dirPath, 0o750); err != nil {
 			return fmt.Errorf("failed to create user dir: %w", err)
 		}
 	}
 
 	for _, file := range files {
 
-		filename, err := internal.ResolveFileNameConflict(userID, file.Filename, isShared, h.DB)
+		// Strip any path from the client provided filename
+		safeName := internal.SanitizeFilename(file.Filename)
+
+		filename, err := internal.ResolveFileNameConflict(userID, safeName, isShared, h.DB)
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Could not resolve filename"})
 		}
@@ -167,6 +170,8 @@ func (h *FileHandler) ListFiles(c *fiber.Ctx) error {
 }
 
 func (h *FileHandler) DownloadFile(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+
 	// Get file name from the endpoint parameters using request context
 	fileID := c.Params("fileid")
 	fileID, err := internal.CleanParam(fileID)
@@ -174,10 +179,10 @@ func (h *FileHandler) DownloadFile(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "File ID provided is not proper"})
 	}
 
-	// Find the full file path
+	// Find the full file path, only if owned by the user or shared
 	var path string
 
-	row := h.DB.QueryRow(`SELECT path FROM metadata WHERE id = ? LIMIT 1`, fileID)
+	row := h.DB.QueryRow(`SELECT path FROM metadata WHERE id = ? AND (user_id = ? OR is_shared = TRUE) LIMIT 1`, fileID, userID)
 	if err := row.Scan(&path); err != nil {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "File not found or access denied"})
 	}
@@ -201,17 +206,23 @@ func (h *FileHandler) DeleteFile(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "File ID provided is not proper"})
 	}
 
-	// Find the full file path and share status
+	// Find the full file path, share status and owner.
 	var shared bool
 	var path string
 	var filename string
+	var ownerID string
 
-	row := h.DB.QueryRow(`SELECT filename, is_shared, path FROM metadata WHERE id = ? LIMIT 1`, fileID)
-	if err = row.Scan(&filename, &shared, &path); err != nil {
+	row := h.DB.QueryRow(`SELECT filename, is_shared, path, user_id FROM metadata WHERE id = ? LIMIT 1`, fileID)
+	if err = row.Scan(&filename, &shared, &path, &ownerID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "File not found"})
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Could not fetch file metadata"})
+	}
+
+	// Check ownership before removing anything from the disk
+	if !shared && ownerID != userID {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "Access denied"})
 	}
 
 	// Deletes the file from the disk
@@ -221,12 +232,7 @@ func (h *FileHandler) DeleteFile(c *fiber.Ctx) error {
 	}
 
 	// Deletes the metadata of the file
-	if shared {
-		_, err = h.DB.Exec(`DELETE FROM metadata WHERE id = ? AND is_shared = ?`, fileID, true)
-	} else {
-		_, err = h.DB.Exec(`DELETE FROM metadata WHERE id = ? AND user_id = ? AND is_shared = ?`, fileID, userID, false)
-	}
-	if err != nil {
+	if _, err = h.DB.Exec(`DELETE FROM metadata WHERE id = ?`, fileID); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to delete metadata"})
 	}
 

--- a/handlers/security_test.go
+++ b/handlers/security_test.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/AumSahayata/cloudboxio/internal"
+	"github.com/AumSahayata/cloudboxio/tests"
+	"github.com/gofiber/fiber/v2"
+)
+
+// seedPrivateFile inserts one private file owned by "test-id" and writes it to
+// disk, returning its metadata id and on-disk path.
+// Every test gets its own directory, Fiber keeps served files open for a while
+// and Windows refuses to remove a file that still has an open handle.
+func seedPrivateFile(t *testing.T, ctx *TestContext) (int64, string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "cloudboxio-test")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
+
+	path := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(path, []byte("top secret"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	res, err := ctx.DB.Exec(
+		`INSERT INTO metadata (user_id, filename, size, path, is_shared) VALUES (?, ?, ?, ?, ?)`,
+		"test-id", "secret.txt", 10, path, false)
+	if err != nil {
+		t.Fatalf("insert metadata: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id, path
+}
+
+func fileRoutes(ctx *TestContext) {
+	handler := NewFileHandler(ctx.DB)
+	ctx.App.Use(internal.JWTProtected())
+	ctx.App.Get("/file/:fileid", handler.DownloadFile)
+	ctx.App.Delete("/file/:fileid", handler.DeleteFile)
+}
+
+func doReq(t *testing.T, ctx *TestContext, method, url, token string) int {
+	t.Helper()
+	req := httptest.NewRequest(method, url, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := ctx.App.Test(req, -1)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// A non-owner must not be able to download another user's private file (IDOR).
+func TestDownloadPrivateFile_DeniedForNonOwner(t *testing.T) {
+	ctx := SetupTestContext(t)
+	tests.SetAdminSetupFlag(ctx.DB, true)
+	id, _ := seedPrivateFile(t, ctx)
+	fileRoutes(ctx)
+
+	attacker, err := internal.GenerateToken("attacker-id", false, 1)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+
+	if got := doReq(t, ctx, "GET", "/file/"+strconv.FormatInt(id, 10), attacker); got != fiber.StatusNotFound {
+		t.Fatalf("expected 404 for non-owner download, got %d", got)
+	}
+}
+
+// The owner can still download their own private file.
+func TestDownloadPrivateFile_AllowedForOwner(t *testing.T) {
+	ctx := SetupTestContext(t)
+	tests.SetAdminSetupFlag(ctx.DB, true)
+	id, _ := seedPrivateFile(t, ctx)
+	fileRoutes(ctx)
+
+	if got := doReq(t, ctx, "GET", "/file/"+strconv.FormatInt(id, 10), ctx.Token); got != fiber.StatusOK {
+		t.Fatalf("expected 200 for owner download, got %d", got)
+	}
+}
+
+// A non-owner must not be able to delete another user's private file, and the
+// file must remain on disk (regression: os.Remove used to run before authz).
+func TestDeletePrivateFile_DeniedAndFileSurvives(t *testing.T) {
+	ctx := SetupTestContext(t)
+	tests.SetAdminSetupFlag(ctx.DB, true)
+	id, path := seedPrivateFile(t, ctx)
+	fileRoutes(ctx)
+
+	attacker, err := internal.GenerateToken("attacker-id", false, 1)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+
+	if got := doReq(t, ctx, "DELETE", "/file/"+strconv.FormatInt(id, 10), attacker); got != fiber.StatusForbidden {
+		t.Fatalf("expected 403 for non-owner delete, got %d", got)
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("file was deleted from disk by a non-owner")
+	}
+}
+
+// The owner can delete their own file and it is removed from disk.
+func TestDeletePrivateFile_AllowedForOwner(t *testing.T) {
+	ctx := SetupTestContext(t)
+	tests.SetAdminSetupFlag(ctx.DB, true)
+	id, path := seedPrivateFile(t, ctx)
+	fileRoutes(ctx)
+
+	if got := doReq(t, ctx, "DELETE", "/file/"+strconv.FormatInt(id, 10), ctx.Token); got != fiber.StatusNoContent {
+		t.Fatalf("expected 204 for owner delete, got %d", got)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("file should have been removed from disk")
+	}
+}

--- a/internal/env.go
+++ b/internal/env.go
@@ -37,6 +37,10 @@ ENABLE_RATE_LIMIT=true
 RATE_LIMIT_MAX=30
 RATE_LIMIT_EXPIRATION_SECOND=30
 MAX_UPLOAD_SIZE_MB=100
+JWT_EXPIRY_HOURS=24
+# Optional TLS (serve HTTPS). Provide paths to a cert and key to enable.
+TLS_CERT_FILE=
+TLS_KEY_FILE=
 `
 
 	_, err = file.WriteString(envContent)

--- a/internal/jwt.go
+++ b/internal/jwt.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -14,6 +15,16 @@ var SecretKey []byte
 
 func InitJWT() {
 	SecretKey = []byte(ensureJWTSecret())
+}
+
+// TokenExpiryHours returns token lifetime in hours from JWT_EXPIRY_HOURS, defaults to 24.
+func TokenExpiryHours() int {
+	if v := os.Getenv("JWT_EXPIRY_HOURS"); v != "" {
+		if hours, err := strconv.Atoi(v); err == nil && hours > 0 {
+			return hours
+		}
+	}
+	return 24
 }
 
 func GenerateToken(userID string, isAdmin bool, expTime int) (string, error) {

--- a/internal/jwt_test.go
+++ b/internal/jwt_test.go
@@ -1,0 +1,84 @@
+package internal
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestTokenExpiryHours(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"default when unset", "", 24},
+		{"value from env", "48", 48},
+		{"invalid falls back", "abc", 24},
+		{"zero falls back", "0", 24},
+		{"negative falls back", "-5", 24},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("JWT_EXPIRY_HOURS", c.env)
+			if c.env == "" {
+				os.Unsetenv("JWT_EXPIRY_HOURS")
+			}
+			if got := TokenExpiryHours(); got != c.want {
+				t.Fatalf("TokenExpiryHours() = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestGenerateTokenClaims(t *testing.T) {
+	tokenStr, err := GenerateToken("user-42", true, 2)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (any, error) {
+		return SecretKey, nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil {
+		t.Fatalf("failed to parse generated token: %v", err)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		t.Fatal("generated token is not valid")
+	}
+
+	if claims["user_id"] != "user-42" {
+		t.Fatalf("user_id = %v, want user-42", claims["user_id"])
+	}
+	if claims["is_admin"] != true {
+		t.Fatalf("is_admin = %v, want true", claims["is_admin"])
+	}
+
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		t.Fatal("token has no expiry")
+	}
+	if remaining := time.Until(exp.Time); remaining < time.Hour || remaining > 2*time.Hour+time.Minute {
+		t.Fatalf("unexpected expiry window: %v", remaining)
+	}
+}
+
+func TestGenerateTokenExpired(t *testing.T) {
+	// A token created with a negative lifetime must not pass validation.
+	tokenStr, err := GenerateToken("user-42", false, -1)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	_, err = jwt.Parse(tokenStr, func(t *jwt.Token) (any, error) {
+		return SecretKey, nil
+	})
+	if err == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+}

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -16,8 +16,8 @@ func InitLogger() {
 	logFileOps := os.Getenv("LOG_FILE_OPS") == "true"
 	logToConsole := os.Getenv("LOG_TO_CONSOLE") == "true"
 
-	_ = os.MkdirAll("logs", os.ModePerm)
-	logfile, err := os.OpenFile("logs/server.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	_ = os.MkdirAll("logs", 0o750)
+	logfile, err := os.OpenFile("logs/server.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
 
 	if err != nil {
 		log.Fatalf("error opening server log file: %v", err)
@@ -33,7 +33,7 @@ func InitLogger() {
 	Error = log.New(output, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
 
 	if logFileOps {
-		fileOpsFile, err := os.OpenFile("logs/fileops.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		fileOpsFile, err := os.OpenFile("logs/fileops.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
 		if err != nil {
 			log.Fatalf("error opening file ops log file: %v", err)
 		}

--- a/internal/middleware.go
+++ b/internal/middleware.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -28,10 +29,13 @@ func JWTProtected() fiber.Handler {
 		}
 		tokenString := parts[1]
 
-		// Verify the token and validate the signature
+		// Verify the token and validate the signature, only HMAC is accepted
 		token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
 			return SecretKey, nil
-		})
+		}, jwt.WithValidMethods([]string{"HS256"}))
 
 		if err != nil || !token.Valid {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid token"})
@@ -49,8 +53,14 @@ func JWTProtected() fiber.Handler {
 }
 
 func CORSMiddleware() fiber.Handler {
-	// Allowed address
-	var allowedOrigins string = "http://127.0.0.1:" + os.Getenv("PORT")
+	// Allowed addresses
+	port := os.Getenv("PORT")
+	allowedOrigins := strings.Join([]string{
+		"http://127.0.0.1:" + port,
+		"http://localhost:" + port,
+		"https://127.0.0.1:" + port,
+		"https://localhost:" + port,
+	}, ", ")
 
 	return cors.New(cors.Config{
 		AllowOrigins: allowedOrigins,

--- a/internal/middleware_test.go
+++ b/internal/middleware_test.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func protectedApp() *fiber.App {
+	app := fiber.New()
+	app.Use(JWTProtected())
+	app.Get("/protected", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+	return app
+}
+
+func hit(t *testing.T, app *fiber.App, token string) int {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/protected", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// A token signed with alg=none must be rejected (algorithm-confusion guard).
+func TestJWTProtected_RejectsNoneAlg(t *testing.T) {
+	claims := jwt.MapClaims{
+		"user_id":  "x",
+		"is_admin": false,
+		"exp":      time.Now().Add(time.Hour).Unix(),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	signed, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign none: %v", err)
+	}
+
+	if got := hit(t, protectedApp(), signed); got != fiber.StatusUnauthorized {
+		t.Fatalf("expected 401 for alg=none token, got %d", got)
+	}
+}
+
+// A properly signed HS256 token must pass.
+func TestJWTProtected_AcceptsHS256(t *testing.T) {
+	token, err := GenerateToken("user-1", false, 1)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if got := hit(t, protectedApp(), token); got != fiber.StatusOK {
+		t.Fatalf("expected 200 for valid HS256 token, got %d", got)
+	}
+}
+
+// Missing token must be rejected.
+func TestJWTProtected_RejectsMissingToken(t *testing.T) {
+	if got := hit(t, protectedApp(), ""); got == fiber.StatusOK {
+		t.Fatal("expected rejection when no token is present")
+	}
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -45,6 +46,32 @@ func ResolveFileNameConflict(userID, originalName string, isShared bool, db *sql
 	}
 
 	return finalname, nil
+}
+
+// SanitizeFilename strips the path and control characters from a filename.
+// Both separators are handled so the result is the same on every OS.
+func SanitizeFilename(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = path.Base(name)
+
+	// Remove control characters
+	var b strings.Builder
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		b.WriteRune(r)
+	}
+
+	// Strip leading dots so "." and ".." cannot be used as a name
+	cleaned := strings.TrimSpace(b.String())
+	cleaned = strings.TrimLeft(cleaned, ".")
+	cleaned = strings.TrimSpace(cleaned)
+
+	if cleaned == "" {
+		return "file"
+	}
+	return cleaned
 }
 
 func CleanParam(param string) (string, error) {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,162 @@
+package internal
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/AumSahayata/cloudboxio/tests"
+)
+
+func TestSanitizeFilename(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "report.pdf", "report.pdf"},
+		{"unix traversal", "../../etc/passwd", "passwd"},
+		{"windows traversal", `..\..\Windows\system32\cfg`, "cfg"},
+		{"leading dots", "...hidden", "hidden"},
+		{"absolute unix", "/var/log/syslog", "syslog"},
+		{"control chars", "bad\x00\x1fname.txt", "badname.txt"},
+		{"only dots", "..", "file"},
+		{"empty", "", "file"},
+		{"spaces trimmed", "  spaced.txt  ", "spaced.txt"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SanitizeFilename(c.in); got != c.want {
+				t.Fatalf("SanitizeFilename(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeFilename_NoPathSeparators(t *testing.T) {
+	got := SanitizeFilename("a/b/c/d.txt")
+	if got != "d.txt" {
+		t.Fatalf("expected basename only, got %q", got)
+	}
+}
+
+func TestCleanParam(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"plain id", "12", "12", false},
+		{"encoded space", "my%20file.txt", "my file.txt", false},
+		{"traversal", "../../etc/passwd", "", true},
+		{"encoded traversal", "..%2F..%2Fpasswd", "", true},
+	}
+
+	// What counts as an absolute path differs per OS.
+	absolute := "/etc/passwd"
+	if runtime.GOOS == "windows" {
+		absolute = `C:\Windows\system32`
+	}
+	cases = append(cases, struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{"absolute path", absolute, "", true})
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := CleanParam(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("CleanParam(%q) expected an error, got %q", c.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CleanParam(%q) returned error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Fatalf("CleanParam(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveFileNameConflict(t *testing.T) {
+	db := tests.SetupTestDB(t)
+	defer db.Close()
+
+	_, err := db.Exec(`INSERT INTO metadata (user_id, filename, path, is_shared) VALUES (?, ?, ?, ?)`,
+		"user-1", "report.pdf", "uploads/user-1/report.pdf", false)
+	if err != nil {
+		t.Fatalf("failed to seed metadata: %v", err)
+	}
+
+	// Taken name gets a counter appended.
+	name, err := ResolveFileNameConflict("user-1", "report.pdf", false, db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "report(1).pdf" {
+		t.Fatalf("got %q, want report(1).pdf", name)
+	}
+
+	// Free name is returned unchanged.
+	name, err = ResolveFileNameConflict("user-1", "notes.txt", false, db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "notes.txt" {
+		t.Fatalf("got %q, want notes.txt", name)
+	}
+
+	// The same name is free for a different user.
+	name, err = ResolveFileNameConflict("user-2", "report.pdf", false, db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "report.pdf" {
+		t.Fatalf("got %q, want report.pdf", name)
+	}
+}
+
+func TestIsAdminSetupAndChangeSetting(t *testing.T) {
+	db := tests.SetupTestDB(t)
+	defer db.Close()
+
+	tests.SetAdminSetupFlag(db, false)
+	if IsAdminSetup(db) {
+		t.Fatal("expected admin setup to be incomplete")
+	}
+
+	if err := ChangeSetting("admin_setup_done", "true", db); err != nil {
+		t.Fatalf("ChangeSetting failed: %v", err)
+	}
+	if !IsAdminSetup(db) {
+		t.Fatal("expected admin setup to be complete after the update")
+	}
+}
+
+func TestGetUsernameByID(t *testing.T) {
+	db := tests.SetupTestDB(t)
+	defer db.Close()
+
+	_, err := db.Exec(`INSERT INTO users (id, username, password, is_admin) VALUES (?, ?, ?, ?)`,
+		"user-1", "alice", "hash", false)
+	if err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+
+	username, err := GetUsernameByID("user-1", db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if username != "alice" {
+		t.Fatalf("got %q, want alice", username)
+	}
+
+	if _, err := GetUsernameByID("missing", db); err == nil {
+		t.Fatal("expected an error for a missing user")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"embed"
 	"io/fs"
 	"net"
@@ -110,7 +111,23 @@ func main() {
 	if err != nil {
 		internal.Error.Fatalf("Failed to listen on %s: %v", addr, err)
 	}
-	internal.Info.Printf("Listening on %s", addr)
+
+	// Serve over HTTPS if a certificate and key are provided
+	certFile := os.Getenv("TLS_CERT_FILE")
+	keyFile := os.Getenv("TLS_KEY_FILE")
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			internal.Error.Fatalf("Failed to load TLS certificate/key: %v", err)
+		}
+		ln = tls.NewListener(ln, &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		})
+		internal.Info.Printf("TLS enabled, listening on %s (https)", addr)
+	} else {
+		internal.Info.Printf("Listening on %s (http)", addr)
+	}
 
 	go func() {
 		if err := app.Listener(ln); err != nil {


### PR DESCRIPTION
Hi! I've been self-hosting CloudBoxIO for a while and fixed a few things along
the way. This PR collects all of them. I'm happy to split it into separate PRs
(access control / tests / Docker / UI) if that's easier to review - just say so.

## Access control

- `GET /api/file/:fileid` returned a file by id without checking who asked for
  it, so any signed-in user could read another user's private file. The query
  now requires the file to be owned by the requester or marked as shared.
- `DELETE /api/file/:fileid` called `os.Remove` before the ownership check, so
  the file was already gone from disk even when the request was refused. The
  check now runs first and the metadata row is deleted by id afterwards.
- Uploaded filenames are reduced to a base name before they touch the disk or
  the database.
- New directories are created with 0750 and log files with 0600, instead of
  0777 and 0666.

## Authentication

- The JWT keyfunc did not verify the signing method. It now accepts HMAC only,
  with `jwt.WithValidMethods` restricted to HS256.
- Token lifetime moved from a hard-coded 72h to `JWT_EXPIRY_HOURS`, default 24h.
- `POST /api/signup` requires at least 8 characters, matching the rule that
  reset password already had.
- CORS additionally allows the https variants of the local origin.

## Optional TLS

If `TLS_CERT_FILE` and `TLS_KEY_FILE` are set, the listener is wrapped in TLS
(minimum version 1.2). If they are empty, nothing changes.

## Unit tests

Closes #5. Added tests for the parts that had none: access control on download
and delete (including that a refused delete leaves the file on disk), the signup
password rule, token generation and expiry configuration, rejection of non-HMAC
tokens, `SanitizeFilename`, `CleanParam`, `ResolveFileNameConflict` and the
settings/user helpers.

## Docker

Closes #3. Multi-stage build: `golang:1.24-alpine` produces a static binary
(`CGO_ENABLED=0`, the sqlite driver is pure Go), the runtime image is
`alpine:3.20` running as a non-root user. State lives in the `/data` volume.
Added `.dockerignore` and a `docker-compose.yml` for `docker compose up --build`.

## UI

Closes #4. The header is now compact and files are shown as dense rows instead of large
cards. Three themes (light, dark, glass) are switchable from the header and
remembered in the browser. Filenames and usernames are rendered with
`textContent` instead of being interpolated into `innerHTML`, which also removes
a stored XSS vector, since the token is kept in `localStorage`.

No build step was added: still plain HTML/CSS/JS embedded in the binary, and
Bootstrap is still used for modals and dropdowns. Note that the interface now
also pulls IBM Plex from Google Fonts; without internet access it falls back to
system fonts. Let me know if you would rather not depend on that and I'll drop it.

## Behaviour changes

- Downloading a private file you don't own returns 404 instead of the file.
- Deleting a private file you don't own returns 403 instead of succeeding.
- Signup rejects passwords shorter than 8 characters.
- New tokens are valid for 24h by default instead of 72h.
- The generated `.env` gains `JWT_EXPIRY_HOURS`, `TLS_CERT_FILE`, `TLS_KEY_FILE`.
  Existing `.env` files keep working, the new keys are optional.